### PR TITLE
Added eth_sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The RPC methods currently implemented are:
 * `eth_newFilter` (includes log/event filters)
 * `eth_sendTransaction`
 * `eth_sendRawTransaction`
+* `eth_sign`
 * `eth_uninstallFilter`
 * `web3_clientVersion`
 

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -388,6 +388,21 @@ Blockchain.prototype.processNextAction = function(override) {
   }
 };
 
+Blockchain.prototype.sign = function(address, dataToSign) {
+    var secretKey = this.accounts[this.toHex(address)].secretKey;
+    var sgn = utils.ecsign(new Buffer(dataToSign, 'hex'), new Buffer(secretKey));
+    var r = utils.fromSigned(sgn.r);
+    var s = utils.fromSigned(sgn.s);
+    var v = utils.bufferToInt(sgn.v);
+    r = utils.toUnsigned(r).toString('hex');
+    s = utils.toUnsigned(s).toString('hex');
+    //utils.ecsign adds 27 to the ECDSA recovery value v,
+    //where other clients like geth do not.
+    v -= 27;
+    v = utils.intToHex(v);
+    return this.toHex(r.concat(s, v));
+};
+
 Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
   var self = this;
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -121,6 +121,10 @@ Manager.prototype.eth_getTransactionCount = function(address, block_number, call
   this.blockchain.getTransactionCount(address, callback);
 }
 
+Manager.prototype.eth_sign = function(address, dataToSign, callback) {
+    callback(null, this.blockchain.sign(address, dataToSign));
+};
+
 Manager.prototype.eth_sendTransaction = function(tx_data, callback) {
   this.blockchain.queueTransaction(tx_data, callback);
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ethereumjs-account": "^1.0.4",
     "ethereumjs-block": "^1.0.2",
     "ethereumjs-tx": "^0.7.3",
-    "ethereumjs-util": "^2.0.4",
+    "ethereumjs-util": "^3.0.0",
     "ethereumjs-vm": "^1.0.4",
     "merkle-patricia-tree": "1.1.2",
     "shelljs": "^0.6.0",


### PR DESCRIPTION
`sgn = web3.eth.sign(signer_address, msghash)` outputs a hex string to sgn with ECDSA r, s, and v concatenated.
One can regenerate the signer of the signature with:

```
utils = require('ethereumjs-util');
var r = sgn.slice(2, 66);
var s = sgn.slice(66,130);
var v = sgn.slice(130, 132);
```

for an explanation of the follwing two lines, see [this issue](https://github.com/ethereumjs/ethereumjs-util/issues/26)

```
var v_buf = new Buffer(v, 'hex');
v = utils.bufferToInt(v_buf)+27;

var pub = utils.ecrecover(new Buffer(msghash, 'hex'), v, new Buffer(r, 'hex'), new Buffer(s, 'hex'));
addr = utils.pubToAddress(pub).toString('hex')
addr = utils.addHexPrefix(addr);
```

addr and signer_address should be the same
