### PR TITLE
Fix eth_hashrate

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -113,11 +113,11 @@ Manager.prototype.eth_mining = function(callback) {
 };
 
 Manager.prototype.eth_hashrate = function(callback) {
-  callback(null, '0x' + utils.intToHex(0));
+  callback(null, utils.addHexPrefix(utils.intToHex(0)));
 };
 
 Manager.prototype.eth_gasPrice = function(callback) {
-  callback(null, '0x' + this.blockchain.gasPrice());
+  callback(null, utils.addHexPrefix(this.blockchain.gasPrice()));
 };
 
 Manager.prototype.eth_getBalance = function(address, block_number, callback) {


### PR DESCRIPTION
I’m guessing ethereumjs-util changed it’s intToHex function to add a
hex prefix.
