### PR TITLE
Added evm_setTimestamp and evm_mineBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SYNOPSIS
 
-Ethereum client for testing and development. Uses ethereumjs to simulate full client behavior and make developing Ethereum applications much faster. Includes all popular RPC functions and features (like events) and can be run deterministically to make development a breeze. 
+Ethereum client for testing and development. Uses ethereumjs to simulate full client behavior and make developing Ethereum applications much faster. Includes all popular RPC functions and features (like events) and can be run deterministically to make development a breeze.
 
 # INSTALL
 
@@ -103,6 +103,8 @@ There’s also special non-standard methods that aren’t included within the or
 
 * `evm_snapshot` : Snapshot the state of the blockchain at its current place. Takes no parameters. Returns the integer id of the snapshot created.
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes one parameter. Reverts to the snapshot id passed, or the latest snapshot.
+* `evm_setTimestamp` : Sets timestamp of current block. Takes one parameter (unix timestamp). This is useful, if your tests have time-constraints for challenge periods etc..
+* `evm_setBlockNumber` : Sets block-number of current block. Takes one parameter (block number). This is useful, if your tests have block-number-constraints for challenge periods etc..
 
 These methods are really powerful within automated testing frameworks. Example uses for these methods are:
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ There’s also special non-standard methods that aren’t included within the or
 * `evm_snapshot` : Snapshot the state of the blockchain at its current place. Takes no parameters. Returns the integer id of the snapshot created.
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes one parameter. Reverts to the snapshot id passed, or the latest snapshot.
 * `evm_setTimestamp` : Sets timestamp of current block. Takes one parameter (unix timestamp). This is useful, if your tests have time-constraints for challenge periods etc..
-* `evm_setBlockNumber` : Sets block-number of current block. Takes one parameter (block number). This is useful, if your tests have block-number-constraints for challenge periods etc..
+* `evm_mineBlocks` : Mines a number of blocks. Takes one parameter (block count). This is useful, if your tests have block-number-constraints for challenge periods etc..
 
 These methods are really powerful within automated testing frameworks. Example uses for these methods are:
 

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -8,6 +8,7 @@ var seedrandom = require('seedrandom');
 var random = require('./random');
 var bip39 = require('bip39')
 var hdkey = require('ethereumjs-wallet/hdkey')
+var util = require('util');
 
 Blockchain = function(options) {
   if (options == null) {
@@ -559,6 +560,7 @@ Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
 
       self.logger.log("  Gas usage: " + utils.bufferToInt(self.toHex(tx_result.gasUsed)));
       self.logger.log("  Block Number: " + self.toHex(block.header.number));
+      self.logger.log("  Logs: " + util.inspect(logs, false, null));
       self.logger.log("");
 
       self.mine(block);

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -34,6 +34,7 @@ Blockchain = function(options) {
   this.mnemonic = options.mnemonic || bip39.entropyToMnemonic(random.randomBytes(16, this.rng));
   this.wallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(this.mnemonic));
   this.wallet_hdpath = "m/44'/60'/0'/0/";
+  this.current_timestamp = 1459678372;
 
   if (options.debug == true) {
     this.vm.on('step', function(info){
@@ -167,7 +168,7 @@ Blockchain.prototype.blockNumber = function() {
 };
 
 Blockchain.prototype.currentTime = function() {
-  return new Date().getTime() / 1000 | 0;
+  return this.current_timestamp;
 };
 
 Blockchain.prototype.mine = function(block) {
@@ -683,11 +684,14 @@ Blockchain.prototype.revert = function(snapshot_id) {
 
 Blockchain.prototype.setTimestamp = function(timestamp) {
   this.blocks[this.blocks.length - 1].header.timestamp = timestamp;
+  this.current_timestamp = timestamp;
   return true;
 };
 
-Blockchain.prototype.setBlockNumber = function(blockNumber) {
-  this.blocks[this.blocks.length - 1].header.number = blockNumber;
+Blockchain.prototype.mineBlocks = function(blockCount) {
+  for (var i=0; i < blockCount; i++) {
+    this.mine(this.createBlock());
+  }
   return true;
 };
 

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -681,4 +681,14 @@ Blockchain.prototype.revert = function(snapshot_id) {
   return true;
 };
 
+Blockchain.prototype.setTimestamp = function(timestamp) {
+  this.blocks[this.blocks.length - 1].header.timestamp = timestamp;
+  return true;
+};
+
+Blockchain.prototype.setBlockNumber = function(blockNumber) {
+  this.blocks[this.blocks.length - 1].header.number = blockNumber;
+  return true;
+};
+
 module.exports = Blockchain;

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -219,8 +219,8 @@ Manager.prototype.evm_setTimestamp = function(timestamp, callback) {
   callback(null, this.blockchain.setTimestamp(timestamp));
 };
 
-Manager.prototype.evm_setBlockNumber = function(blockNumber, callback) {
-  callback(null, this.blockchain.setBlockNumber(blockNumber));
+Manager.prototype.evm_mineBlocks = function(blockCount, callback) {
+  callback(null, this.blockchain.mineBlocks(blockCount));
 };
 
 module.exports = Manager;

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -215,4 +215,12 @@ Manager.prototype.evm_revert = function(snapshot_id, callback) {
   callback(null, this.blockchain.revert(snapshot_id));
 };
 
+Manager.prototype.evm_setTimestamp = function(timestamp, callback) {
+  callback(null, this.blockchain.setTimestamp(timestamp));
+};
+
+Manager.prototype.evm_setBlockNumber = function(blockNumber, callback) {
+  callback(null, this.blockchain.setBlockNumber(blockNumber));
+};
+
 module.exports = Manager;

--- a/test/requests.js
+++ b/test/requests.js
@@ -494,6 +494,76 @@ var tests = function(web3) {
       });
     });
   });
+
+  describe("evm_setBlockNumber", function() {
+    it("should set current block number to specified value", function(done) {
+      web3.eth.getBlockNumber(function(err, result) {
+        if (err) return done(err);
+
+        assert.deepEqual(result, 4);
+
+        var newBlockNumber = 100;
+
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "evm_setBlockNumber",
+          id: 0,
+          params: [newBlockNumber]
+        }, function(err, result) {
+          if (err) return done(err);
+
+          assert.deepEqual(result.result, true);
+
+          web3.eth.getBlockNumber(function(err, result) {
+            if (err) return done(err);
+
+            assert.deepEqual(result, newBlockNumber);
+
+            done();
+          });
+
+        });
+
+      });
+
+      // Note: We'll assert the block number changes on transactions.
+    });
+  });
+
+  describe("evm_setTimestamp", function() {
+    it("should set current block timestamp to specified value", function(done) {
+      web3.eth.getBlock("latest", function(err, block) {
+        if (err) return done(err);
+
+        var currentTimestamp = block.timestamp;
+
+        var newTimestamp = currentTimestamp + 2000;
+
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "evm_setTimestamp",
+          id: 0,
+          params: [newTimestamp]
+        }, function(err, result) {
+          if (err) return done(err);
+
+          assert.deepEqual(result.result, true);
+
+          web3.eth.getBlock("latest", function(err, block) {
+            if (err) return done(err);
+
+            assert.deepEqual(block.timestamp, newTimestamp);
+
+            done();
+          });
+
+        });
+
+      });
+
+      // Note: We'll assert the block number changes on transactions.
+    });
+  });
 };
 
 var logger = {

--- a/test/requests.js
+++ b/test/requests.js
@@ -495,20 +495,20 @@ var tests = function(web3) {
     });
   });
 
-  describe("evm_setBlockNumber", function() {
+  describe("evm_mineBlocks", function() {
     it("should set current block number to specified value", function(done) {
-      web3.eth.getBlockNumber(function(err, result) {
+      web3.eth.getBlockNumber(function(err, currentBlockNumber) {
         if (err) return done(err);
 
-        assert.deepEqual(result, 4);
+        assert.deepEqual(currentBlockNumber, 4);
 
-        var newBlockNumber = 100;
+        var blocksToMine = 100;
 
         web3.currentProvider.sendAsync({
           jsonrpc: "2.0",
-          method: "evm_setBlockNumber",
+          method: "evm_mineBlocks",
           id: 0,
-          params: [newBlockNumber]
+          params: [blocksToMine]
         }, function(err, result) {
           if (err) return done(err);
 
@@ -517,7 +517,7 @@ var tests = function(web3) {
           web3.eth.getBlockNumber(function(err, result) {
             if (err) return done(err);
 
-            assert.deepEqual(result, newBlockNumber);
+            assert.deepEqual(result, blocksToMine + currentBlockNumber);
 
             done();
           });


### PR DESCRIPTION
Many test scenarios have time constraints. For example off chain trading requires a third party to have enough time to respond to your action. In order to not have to wait in real-time, it makes sense to offer evm calls to manipulate timestamp and block number easily. I added this functionality with `evm_setTimestamp` and `evm_mineBlocks`. The timestamp is now static and predictable.
