### PR TITLE
Add ability to use testrpc through a Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mhart/alpine-node:5.10
+
+WORKDIR /src
+ADD . .
+
+RUN apk add --no-cache make gcc g++ python git bash
+RUN npm install
+
+EXPOSE 8545
+
+ENTRYPOINT ["node", "./bin/testrpc"]


### PR DESCRIPTION
Allows testrpc to be run though Docker so we dont need npm on the host machine.
If this gets in will require an automated build setup on the Dockerhub and probably updated README docs as well so show usage.

default usage (for this PR) -

```
docker build -t ethereumjs/testrpc .
docker run -d -p 8545:8545 ethereumjs/testrpc
```
