### PR TITLE
Add Docker based readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ Note that private keys are 64 characters long, and must be input as a 0x-prefixe
 
 An HD wallet will not be created for you when using `--account`.
 
+##### Docker
+
+The Simplest way to get stared with the Docker image:
+
+```Bash
+docker run -d -p 8545:8545 ethereumjs/testrpc:latest
+```
+
+To pass options to testrpc through Docker simply add the arguments to
+the run command:
+
+```Bash
+docker run -d -p 8545:8545 ethereumjs/testrpc:latest -a 10 --debug
+```
+
+To build the Docker container from source:
+
+```Bash
+git clone https://github.com/ethereumjs/testrpc.git && cd testrpc
+docker build -t etherumjs/testrpc .
+```
+
 ##### Library
 
 As a Web3 provider:


### PR DESCRIPTION
Some docs based on https://github.com/ethereumjs/testrpc/commit/649f79f7ede14f8ee718d47ff35e4e8423d28afe just merged.

assumes the dockerhub repo gets set up at ethereumjs/testrpc...
