### PR TITLE
Better account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ Having problems? Be sure to check out the [FAQ](https://github.com/ethereumjs/te
 ##### Command Line
 
 ```Bash
+$ testrpc --help
+
 $ testrpc <options>
 ```
 
 Options:
 
-* `-a` or `--accounts`: Specify the number of accounts to generate at startup.
+* `-a` or `--accounts`: Specify the list of accounts to generate at startup.
 * `-b` or `--blocktime`: Specify blocktime in seconds for automatic mining. Default is 0 and no auto-mining.
 * `-d` or `--deterministic`: Generate deterministic addresses based on a pre-defined mnemonic.
 * `-m` or `--mnemonic`: Use a specific HD wallet mnemonic to generate initial addresses.

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var argv = require('yargs').argv;
+var yargs =require('yargs'); 
 var TestRPC = require('..');
 var pkg = require("../package.json");
 var util = require("ethereumjs-util");
@@ -7,9 +7,101 @@ var URL = require("url");
 var Web3 = require("web3");
 var web3 = new Web3(); // Used only for its BigNumber library.
 
+yargs
+.usage('Usage: $0 [options...] ')
+// .command('start', 'Start the server')
+.option('port', {
+  describe: 'The port to serve',
+  alias: 'p',
+  type: 'string',   // for compativility with previous version
+  default: '8545'
+})
+.option('hostname', {
+  describe: 'Hostname to listen on. Defaults to Node\'s server.listen() default.',
+  alias: 'h',
+  type: 'string'
+})
+.option('debug', {
+  describe: 'Output VM opcodes for debugging',
+  type: 'boolean',
+  default: false
+})
+.option('deterministic', {
+  describe: 'Generate deterministic addresses based on a pre-defined mnemonic.',
+  alias: 'd',
+  type: 'boolean',
+  default: false
+})
+.option('seed', {
+  describe: 'Use arbitrary data to generate the HD wallet mnemonic to be used.',
+  alias: 's',
+  type: 'string',
+  default: 'TestRPC is awesome!'
+})
+.option('mnemonic', {
+  describe: 'Use a specific HD wallet mnemonic to generate initial addresses.',
+  alias: 'm',
+  type: 'string'
+})
+.option('total_accounts', {
+  describe: 'Number of accounts to generate at startup.',
+  alias: 't',
+  type: 'integer',
+  default: 10
+})
+.option('blocktime', {
+  describe: 'Specify blocktime in seconds for automatic mining. Default is 0 and no auto-mining.',
+  alias: 'b',
+  type: 'integer',
+  default: 0
+})
+.option('gasPrice', {
+  describe: 'Use a custom Gas Price (defaults to 1)',
+  alias: 'g',
+  type: 'integer',
+  default: 1
+})
+.option('gasLimit', {
+  describe: 'Use a custom Gas Limit (defaults to 0x47E7C4)',
+  alias: 'l',
+  type: 'integer',
+  default: 4712388 // 0x47E7C4
+})
+.option('accounts', {
+  describe: 'Specify the accounts to generate at startup. testrpc --account="<privatekey with 0x>,<balance in wei>" [--account="<privatekey>,balance"]',
+  alias: 'a',
+  type: 'string'
+})
+.option('fork', {
+  describe: 'Fork from another currently running Ethereum client at a given block. Input should be the HTTP location and port of the other client, e.g. http://localhost:8545. You can optionally specify the block to fork from using an @ sign: http://localhost:8545@1599200',
+  alias: 'f',
+  type: 'boolean',
+  default: false
+})
+.option('network_id', {
+  describe: 'The network id',
+  alias: 'i',
+  type: 'integer',
+  default: 1377
+})
+.option('verbose', {
+  describe: 'Tell me more!',
+  alias: 'v',
+  type: 'boolean',
+  default: false
+})
+.option('help', {
+  describe: 'Show some help',
+  type: 'boolean',
+  default: false
+});
+
+var argv = yargs.argv;
+
+
 function parseAccounts(accounts) {
   function splitAccount(account) {
-    account = account.split(',')
+    account = account.split(',');
     return {
       secretKey: account[0],
       balance: account[1]
@@ -21,35 +113,38 @@ function parseAccounts(accounts) {
   else if (!Array.isArray(accounts))
     return;
 
-  var ret = []
+  var ret = [];
   for (var i = 0; i < accounts.length; i++) {
     ret.push(splitAccount(accounts[i]));
   }
   return ret;
 }
 
-if (argv.d || argv.deterministic) {
-  argv.s = "TestRPC is awesome!";
-}
-
 var options = {
-  port: argv.p || argv.port || "8545",
-  hostname: argv.h || argv.hostname,
+  port: argv.port,
+  hostname: argv.hostname,
   debug: argv.debug,
-  seed: argv.s || argv.seed,
-  mnemonic: argv.m || argv.mnemonic,
-  total_accounts: argv.a || argv.accounts,
-  blocktime: argv.b || argv.blocktime,
-  gasPrice: argv.g || argv.gasPrice,
-  gasLimit: argv.l || argv.gasLimit,
+  seed: argv.seed,
+  mnemonic: argv.mnemonic,
+  total_accounts: argv.total_accounts,
+  blocktime: argv.blocktime,
+  gasPrice: argv.gasPrice,
+  gasLimit: argv.gasLimit,
   accounts: parseAccounts(argv.account),
-  fork: argv.f || argv.fork || false,
-  network_id: argv.i || argv.networkId,
-  verbose: argv.v || argv.verbose,
+  fork: argv.fork,
+  network_id: argv.network_id,
+  verbose: argv.verbose,
   logger: console
-}
+};
 
 var fork_address;
+
+if (argv.help) {
+  console.log('This is TestRPC version '+ pkg.version);
+  console.log('More at ' + pkg.repository.url);
+  yargs.showHelp();
+  process.exit(0);
+}
 
 // If we're forking from another client, don't try to use the same port.
 if (options.fork) {
@@ -70,7 +165,6 @@ if (options.fork) {
 var server = TestRPC.server(options);
 
 console.log("EthereumJS TestRPC v" + pkg.version);
-
 server.listen(options.port, options.hostname, function(err, state) {
   if (err) {
     console.log(err);
@@ -100,7 +194,7 @@ server.listen(options.port, options.hostname, function(err, state) {
     console.log("HD Wallet");
     console.log("==================");
     console.log("Mnemonic:      " + state.mnemonic);
-    console.log("Base HD Path:  " + state.wallet_hdpath + "{account_index}")
+    console.log("Base HD Path:  " + state.wallet_hdpath + "{account_index}");
   }
 
   if (options.gasPrice) {

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -94,6 +94,11 @@ yargs
   describe: 'Show some help',
   type: 'boolean',
   default: false
+})
+.option('version', {
+  describe: 'Show the version',
+  type: 'boolean',
+  default: false
 });
 
 var argv = yargs.argv;
@@ -143,6 +148,11 @@ if (argv.help) {
   console.log('This is TestRPC version '+ pkg.version);
   console.log('More at ' + pkg.repository.url);
   yargs.showHelp();
+  process.exit(0);
+}
+
+if (argv.version) {
+  console.log('TestRPC version '+ pkg.version);
   process.exit(0);
 }
 

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -188,7 +188,8 @@ server.listen(options.port, options.hostname, function(err, state) {
   var addresses = Object.keys(accounts);
 
   addresses.forEach(function(address, index) {
-    console.log("(" + index + ") " + address);
+    var balanceInEth = util.bufferToInt(accounts[address].account.balance)*1e-18;
+    console.log("(" + index + ") " + address + ' - ' + balanceInEth + ' ETH' );
   });
 
   console.log("");

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -51,14 +51,14 @@ StateManager = function(options) {
   if (options.gasPrice) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
-}
+};
 
 StateManager.prototype.initialize = function(options, callback) {
   var self = this;
 
   var accounts = [];
 
-  var total_accounts = this.total_accounts || 10;
+  var total_accounts = options.total_accounts || 10;
 
   if (options.accounts) {
     accounts = options.accounts.map(this.createAccount.bind(this));
@@ -116,8 +116,8 @@ StateManager.prototype.createAccount = function(opts) {
   if (opts.secretKey) {
     secretKey = utils.toBuffer(to.hex(opts.secretKey));
   } else {
-    var acct = this.wallet.derivePath(this.wallet_hdpath + opts.index) // index is a number
-    secretKey = acct.getWallet().getPrivateKey() // Buffer
+    var acct = this.wallet.derivePath(this.wallet_hdpath + opts.index); // index is a number
+    secretKey = acct.getWallet().getPrivateKey();                       // Buffer
   }
 
   var publicKey = utils.privateToPublic(secretKey);
@@ -126,7 +126,7 @@ StateManager.prototype.createAccount = function(opts) {
   var account = new Account();
 
   if (opts.balance) {
-    account.balance = to.hex(opts.balance)
+    account.balance = to.hex(opts.balance);
   } else {
     account.balance = "0x0000000000000056bc75e2d63100000";
   }
@@ -147,7 +147,7 @@ StateManager.prototype.blockNumber = function() {
 
 StateManager.prototype.gasPrice = function() {
   return this.gasPriceVal;
-}
+};
 
 StateManager.prototype.getBalance = function(address, number, callback) {
   this.blockchain.getBalance(address, number, function(err, balance) {
@@ -156,7 +156,7 @@ StateManager.prototype.getBalance = function(address, number, callback) {
     }
     callback(err, balance);
   });
-}
+};
 
 StateManager.prototype.getTransactionCount = function(address, number, callback) {
   this.blockchain.getNonce(address, number, function(err, nonce) {
@@ -165,7 +165,7 @@ StateManager.prototype.getTransactionCount = function(address, number, callback)
     }
     callback(err, nonce);
   });
-}
+};
 
 StateManager.prototype.getCode = function(address, number, callback) {
   this.blockchain.getCode(address, number, function(err, code) {
@@ -174,7 +174,7 @@ StateManager.prototype.getCode = function(address, number, callback) {
     }
     callback(err, code);
   });
-}
+};
 
 StateManager.prototype.queueRawTransaction = function(rawTx, callback) {
   var data = new Buffer(utils.stripHexPrefix(rawTx), 'hex');
@@ -187,7 +187,7 @@ StateManager.prototype.queueRawTransaction = function(rawTx, callback) {
     gasPrice: (tx.gasPrice && tx.gasPrice.length) ? '0x'+tx.gasPrice.toString('hex') : null,
     value:    (tx.value    && tx.value.length   ) ? '0x'+tx.value.toString('hex')    : null,
     data:     (tx.data     && tx.data.length    ) ? '0x'+tx.data.toString('hex')     : null,
-  }
+  };
 
   this.queueTransaction("eth_sendRawTransaction", txParams, callback);
 };
@@ -203,7 +203,7 @@ StateManager.prototype.queueStorage = function(address, position, block, callbac
 
   // We know there's work, so get started.
   this.processNextAction();
-}
+};
 
 StateManager.prototype.queueTransaction = function(method, tx_params, callback) {
   if (tx_params.from == null) {
@@ -264,7 +264,7 @@ StateManager.prototype.queueTransaction = function(method, tx_params, callback) 
 
     // Edit: Why is this here?
     if (rawTx.to == '0x0') {
-      delete rawTx.to
+      delete rawTx.to;
     }
 
     var tx = new FakeTransaction(rawTx);
@@ -459,6 +459,6 @@ StateManager.prototype.hasContractCode = function(address, callback) {
       callback( null, true );
     }
   });
-}
+};
 
 module.exports = StateManager;

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -60,16 +60,21 @@ StateManager.prototype.initialize = function(options, callback) {
 
   var total_accounts = options.total_accounts || 10;
 
+  console.log('TEST');
+
+  console.log('opt.accounts', options.accounts);
+  console.log('total', total_accounts);
+  // ADD ACCOUNTS HERE
   if (options.accounts) {
     accounts = options.accounts.map(this.createAccount.bind(this));
-  } else {
-    for (var i = 0; i < total_accounts; i++) {
-      accounts.push(self.createAccount({
-        index: i
-      }));
-    }
+  } 
+    
+  for (var i = options.accounts.length || 0; i < total_accounts; i++) {
+    accounts.push(self.createAccount({
+      index: i
+    }));
   }
-
+  
   this.coinbase = to.hex(accounts[0].address);
   this.accounts = {};
 
@@ -128,7 +133,8 @@ StateManager.prototype.createAccount = function(opts) {
   if (opts.balance) {
     account.balance = to.hex(opts.balance);
   } else {
-    account.balance = "0x0000000000000056bc75e2d63100000";
+    //account.balance = "0x0000000000000056bc75e2d63100000"; // 100 ETH
+    account.balance = "0x00000000000152d02c7e14af6000000"; // 100`000 ETH
   }
 
   var data = {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -55,21 +55,16 @@ StateManager = function(options) {
 
 StateManager.prototype.initialize = function(options, callback) {
   var self = this;
-
   var accounts = [];
-
   var total_accounts = options.total_accounts || 10;
+  var nbAccounts = 0;
 
-  console.log('TEST');
-
-  console.log('opt.accounts', options.accounts);
-  console.log('total', total_accounts);
-  // ADD ACCOUNTS HERE
   if (options.accounts) {
+    nbAccounts = options.accounts.length;
     accounts = options.accounts.map(this.createAccount.bind(this));
   } 
     
-  for (var i = options.accounts.length || 0; i < total_accounts; i++) {
+  for (var i = nbAccounts || 0; i < total_accounts; i++) {
     accounts.push(self.createAccount({
       index: i
     }));

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -128,8 +128,7 @@ StateManager.prototype.createAccount = function(opts) {
   if (opts.balance) {
     account.balance = to.hex(opts.balance);
   } else {
-    //account.balance = "0x0000000000000056bc75e2d63100000"; // 100 ETH
-    account.balance = "0x00000000000152d02c7e14af6000000"; // 100`000 ETH
+    account.balance = "0x0000000000000056bc75e2d63100000"; // 100 ETH
   }
 
   var data = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-testrpc",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "bin": {
     "testrpc": "./bin/testrpc"
   },


### PR DESCRIPTION
This PR should only be applied after #165 (since #165 contains the fix for the number of accounts that are created.

In the examples below some of the addresses and amounts are shortened for the sake of readability.

So far, we could do:
`testrpc -t 7`
to get 7 accounts.

or
`testrpc --account="0xabc123000....000, 3300000..." --account="0xabc123000000.....00000001, 33000....."`
to get 2 specific accounts.

With this PR, it becomes possible to issue:
`testrpc --account="0xabc123000....000, 3300000..." --account="0xabc123000000.....00000001, 33000....." -t 5`
and get the best of both: the accounts you specified, as well as some automatically generated accounts up to the amount you wish.

```
Available Accounts
==================
(0) 0x85bd94190bf78f81fe15058545a6483c3d3c30fe - 330 ETH
(1) 0x36a3421f972f3370f2cbd1322c2c896409d9c894 - 330 ETH
(2) 0x22d491bde2303f2f43325b2108d26f1eaba1e32b - 100000 ETH
(3) 0xe11ba2b4d45eaed5996cd0823791e0c93114882d - 100000 ETH
(4) 0xd03ea8624c8c5987235048901fb614fdca89b117 - 100000 ETH
```

NOTE: This PR also raises the default balance of accounts from 100 ETH to 100k ETH as using tools such as truffle can exhaust an account pretty quick, especially when running tests. Also, why be happy with 100 when you can have 100k 😄 

Note that a call such as:
`testrpc --account="0xabc1230000...00, 330000..." --account="0xabc12300...000001, 330000..." --account="0xabc12300...00002, 330000..." -t 2`
will return:

```
Available Accounts
==================
(0) 0x85bd94190bf78f81fe15058545a6483c3d3c30fe - 330 ETH
(1) 0x36a3421f972f3370f2cbd1322c2c896409d9c894 - 330 ETH
(2) 0x50525a16b8d6aa19f59a01835ffaab9fb3f7652e - 330 ETH
```

So if accounts are provided, the total_accounts number is ignored if below the amount of specified accounts.
