### PR TITLE
start_mining/stop_mining, refactoring of #155

### DIFF
--- a/bin/testrpc
+++ b/bin/testrpc
@@ -46,7 +46,6 @@ var options = {
   fork: argv.f || argv.fork || false,
   network_id: argv.i || argv.networkId,
   verbose: argv.v || argv.verbose,
-  no_mine_after_transaction: argv.n || argv.noMineAfterTransaction || false,
   logger: console
 }
 

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -46,6 +46,7 @@ var options = {
   fork: argv.f || argv.fork || false,
   network_id: argv.i || argv.networkId,
   verbose: argv.v || argv.verbose,
+  no_mine_after_transaction: argv.n || argv.noMineAfterTransaction || false,
   logger: console
 }
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -9,6 +9,7 @@ var Trie = require("merkle-patricia-tree");
 var Web3 = require("web3");
 var utils = require("ethereumjs-util");
 var async = require('async');
+var Heap = require("heap");
 
 function BlockchainDouble(options) {
   var self = this;
@@ -200,6 +201,7 @@ BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
     if (tx.from.toString('hex') != address.toString('hex')) return;
 
     var pending_nonce = to.number(tx.nonce);
+    console.log('found nonce', pending_nonce);
     //If this is the first queued nonce for this address we found,
     //or it's higher than the previous highest, note it.
     if (nonce===null || pending_nonce > nonce) {
@@ -223,11 +225,67 @@ BlockchainDouble.prototype.queueTransaction = function(tx) {
   this.pending_transactions.push(tx);
 };
 
+BlockchainDouble.prototype.SortByPriceAndNonce = function(){
+  //Sorts transactions like I believe geth does.
+  //See the description of 'SortByPriceAndNonce' at
+  //https://github.com/ethereum/go-ethereum/blob/290e851f57f5d27a1d5f0f7ad784c836e017c337/core/types/transaction.go
+  //
+  var self = this;
+  var sortedByNonce = {};
+  for (idx in self.pending_transactions){
+    var tx = self.pending_transactions[idx]
+    console.log(tx.from.toString('hex'));
+    if (!sortedByNonce[tx.from.toString('hex')]){
+      sortedByNonce[tx.from.toString('hex')] = [tx];
+    }else{
+      Array.prototype.push.apply(sortedByNonce[tx.from.toString('hex')], [tx]);
+    }
+  }
+  var priceSort = function(a,b){
+    return parseInt(a.gasPrice.toString('hex'),16)-parseInt(b.gasPrice.toString('hex'),16);
+  }
+  var nonceSort = function(a,b){
+    return parseInt(b.nonce.toString('hex'),16)-parseInt(a.nonce.toString('hex'),16);
+  }
+
+  //Now sort each address by nonce
+  for (address in sortedByNonce){
+    console.log(address);
+    console.log(sortedByNonce[address]);
+    Array.prototype.sort.apply(sortedByNonce[address], nonceSort)
+  }
+
+  //Initialise a heap, sorted by price, for the head transaction from each account.
+  var heap = new Heap(priceSort);
+  for (address in sortedByNonce){
+    heap.push(sortedByNonce[address][0]);
+    //Remove the transaction from sortedByNonce
+    sortedByNonce[address].splice(0,1);
+  }
+
+  //Now reorder our transactions. Compare the next transactions from each account, and choose
+  //the one with the highest gas price.
+  sorted_transactions = [];
+  while (heap.size()>0){
+    best = heap.pop();
+    console.log('popped with nonce', best.nonce.toString('hex'), ' and gas limit ', best.gasLimit.toString('hex'));
+    if (sortedByNonce[best.from.toString('hex')].length>0){
+      //Push on the next transaction from this account
+      heap.push(sortedByNonce[address][0]);
+      sortedByNonce[address].splice(0,1);
+    }
+    Array.prototype.push.apply(sorted_transactions, [best]);
+  }
+  self.pending_transactions = sorted_transactions;
+}
+
 BlockchainDouble.prototype.processNextBlock = function(callback) {
   var self = this;
   var block = this.createBlock();
   var successfullyAddedTransactions = [];
 
+  //First, sort our transactions like geth does
+  this.SortByPriceAndNonce();
   function tryTransactionIdx(txnumber){
     Array.prototype.push.apply(block.transactions, [self.pending_transactions[txnumber]]);
     self._checkpointTrie();

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -224,18 +224,17 @@ BlockchainDouble.prototype.queueTransaction = function(tx) {
   this.pending_transactions.push(tx);
 };
 
-BlockchainDouble.prototype.SortByPriceAndNonce = function(){
-  //Sorts transactions like I believe geth does.
-  //See the description of 'SortByPriceAndNonce' at
-  //https://github.com/ethereum/go-ethereum/blob/290e851f57f5d27a1d5f0f7ad784c836e017c337/core/types/transaction.go
-  //
+BlockchainDouble.prototype.sortByPriceAndNonce = function() {
+  // Sorts transactions like I believe geth does.
+  // See the description of 'SortByPriceAndNonce' at
+  // https://github.com/ethereum/go-ethereum/blob/290e851f57f5d27a1d5f0f7ad784c836e017c337/core/types/transaction.go
   var self = this;
   var sortedByNonce = {};
   for (idx in self.pending_transactions){
     var tx = self.pending_transactions[idx]
     if (!sortedByNonce[to.hex(tx.from)]){
       sortedByNonce[to.hex(tx.from)] = [tx];
-    }else{
+    } else {
       Array.prototype.push.apply(sortedByNonce[to.hex(tx.from)], [tx]);
     }
   }
@@ -246,12 +245,12 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
     return parseInt(to.hex(a.nonce),16) - parseInt(to.hex(b.nonce),16)
   }
 
-  //Now sort each address by nonce
+  // Now sort each address by nonce
   for (address in sortedByNonce){
     Array.prototype.sort.apply(sortedByNonce[address], [nonceSort])
   }
 
-  //Initialise a heap, sorted by price, for the head transaction from each account.
+  // Initialise a heap, sorted by price, for the head transaction from each account.
   var heap = new Heap(priceSort);
   for (address in sortedByNonce){
     heap.push(sortedByNonce[address][0]);
@@ -259,8 +258,8 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
     sortedByNonce[address].splice(0,1);
   }
 
-  //Now reorder our transactions. Compare the next transactions from each account, and choose
-  //the one with the highest gas price.
+  // Now reorder our transactions. Compare the next transactions from each account, and choose
+  // the one with the highest gas price.
   sorted_transactions = [];
   while (heap.size()>0){
     best = heap.pop();
@@ -272,7 +271,7 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
     Array.prototype.push.apply(sorted_transactions, [best]);
   }
   self.pending_transactions = sorted_transactions;
-}
+};
 
 BlockchainDouble.prototype.processNextBlock = function(callback) {
   var self = this;
@@ -280,138 +279,106 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
   var successfullyAddedTransactions = [];
 
   //First, sort our transactions like geth does
-  this.SortByPriceAndNonce();
-  function tryTransactionIdx(txnumber){
-    Array.prototype.push.apply(block.transactions, [self.pending_transactions[txnumber]]);
-    self._checkpointTrie();
-    self.vm.runBlock({block: block,
-      generate:true}, function(err,results){
-        //Regardless of whether we error'd or not, this was just
-        //an experiment to see if the transaction was good, so
-        //revert the trie
-        //
-        self._revertTrie();
-        if (err || results.error) {
-          err = err || results.error;
+  this.sortByPriceAndNonce();
 
-          if (err instanceof Error == false) {
-            err = new Error("VM error: " + err);
-          }
+  // Grab only the transactions that can fit within the block
+  var currentTransactions = [];
+  var totalGasLimit = 0;
+  var maxGasLimit = to.number(block.header.gasLimit);
 
-          block.transactions.pop(); //Remove the bad transaction from the block
+  while (this.pending_transactions.length > 0) {
+    var tx = this.pending_transactions[0];
+    var gasLimit = to.number(tx.gasLimit);
 
-          //If this is the first queued transaction, it must be bad
-          //so throw after deleting it from pending
-          //transactions (transactions we don't try first might just not
-          //be able to fit in the current block due to gas);
-
-          if (txnumber===0){
-            self.pending_transactions.splice(0,1);
-            callback(err);
-            return;
-          }
-        }else{
-          //Otherwise, went in the block okay.
-          //Note that we want to remove it from our transaction pool
-          Array.prototype.push.apply(successfullyAddedTransactions, [txnumber]);
-        }
-
-        if (txnumber < self.pending_transactions.length-1){
-          return tryTransactionIdx(txnumber+1);
-        }else{
-          //Otherwise, mine the block as we've tried all the
-          //pending transactions for now
-          mineBlock();
-        }
-      });
+    if (totalGasLimit + gasLimit <= maxGasLimit) {
+      totalGasLimit += gasLimit;
+      this.pending_transactions.shift();
+      currentTransactions.push(tx);
+    } else {
+      // Next one won't fit. Break.
+      break;
+    }
   }
 
-  function mineBlock(){
-    self._checkpointTrie();
-    self.vm.runBlock({
-      block: block,
-      generate: true,
-    }, function(err, results) {
-      //Remove transactions that were added from the pending transactions pool
-      //We go backwards so that deleting transactions doesn't mess up our
-      //indices
-      for (var i = successfullyAddedTransactions.length-1; i>=0; i--){
-        self.pending_transactions.splice(successfullyAddedTransactions[i],1);
+  // Remember, we ensured transactions had a valid gas limit when they were queued (in the state manager).
+  // If we run into a case where we can't process any because one is higher than the gas limit,
+  // then it's a serious issue. This should never happen, but let's check anyway.
+  if (currentTransactions.length == 0 && this.pending_transactions.length > 0) {
+    // Error like geth.
+    return callback("Unexpected error condition: next transaction exceeds block gas limit")
+  }
+
+  // Add transactions to the block.
+  Array.prototype.push.apply(block.transactions, currentTransactions);
+
+  //self._checkpointTrie();
+  self.vm.runBlock({
+    block: block,
+    generate: true,
+  }, function(err, results) {
+    if (err || results.error) {
+      err = err || results.error;
+
+      if (err instanceof Error == false) {
+        err = new Error("VM error: " + err);
       }
 
-      if (err || results.error) {
-        //This is surprising, because we just tried this block and
-        //then reverted it after it was successful. But you can never be too
-        //careful...
-        err = err || results.error;
+      //self._revertTrie();
 
-        if (err instanceof Error == false) {
-          err = new Error("VM error: " + err);
-        }
+      callback(err);
+      return;
+    }
 
-        self._revertTrie();
+    var logs = [];
+    var receipts = [];
 
-        callback(err);
-        return;
-      }
+    var totalBlockGasUsage = 0;
 
-
-      var logs = [];
-      var receipts = [];
-
-      var totalBlockGasUsage = 0;
-
-      results.results.forEach(function(result) {
-        totalBlockGasUsage += to.number(result.gasUsed);
-      });
-
-      block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
-
-      for (var v = 0; v < results.receipts.length; v++) {
-        var result = results.results[v];
-        var receipt = results.receipts[v];
-        var tx = block.transactions[v];
-        var tx_hash = tx.hash();
-        var tx_logs = [];
-
-        for (var i = 0; i < receipt.logs.length; i++) {
-          var log = receipt.logs[i];
-          var address = to.hex(log[0]);
-          var topics = []
-
-          for (var j = 0; j < log[1].length; j++) {
-            topics.push(to.hex(log[1][j]));
-          }
-
-          var data = to.hex(log[2]);
-
-          var log = new Log({
-            logIndex: to.hex(i),
-            transactionIndex: to.hex(v),
-            transactionHash: tx_hash,
-            block: block,
-            address: address,
-            data: data,
-            topics: topics,
-            type: "mined"
-          });
-
-          logs.push(log);
-          tx_logs.push(log);
-        }
-
-        receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
-      }
-
-      self.putBlock(block, logs, receipts);
-      callback(null, results);
+    results.results.forEach(function(result) {
+      totalBlockGasUsage += to.number(result.gasUsed);
     });
-  }
-  if (self.pending_transactions.length > 0){
-    tryTransactionIdx(0);
-  } else {
-    mineBlock();
-  }
+
+    block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
+
+    for (var v = 0; v < results.receipts.length; v++) {
+      var result = results.results[v];
+      var receipt = results.receipts[v];
+      var tx = block.transactions[v];
+      var tx_hash = tx.hash();
+      var tx_logs = [];
+
+      for (var i = 0; i < receipt.logs.length; i++) {
+        var log = receipt.logs[i];
+        var address = to.hex(log[0]);
+        var topics = []
+
+        for (var j = 0; j < log[1].length; j++) {
+          topics.push(to.hex(log[1][j]));
+        }
+
+        var data = to.hex(log[2]);
+
+        var log = new Log({
+          logIndex: to.hex(i),
+          transactionIndex: to.hex(v),
+          transactionHash: tx_hash,
+          block: block,
+          address: address,
+          data: data,
+          topics: topics,
+          type: "mined"
+        });
+
+        logs.push(log);
+        tx_logs.push(log);
+      }
+
+      receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
+    }
+
+    self.putBlock(block, logs, receipts);
+    callback(null, results);
+  });
 };
 
 BlockchainDouble.prototype.getAccount = function(address, number, callback) {

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -198,10 +198,9 @@ BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
   this.pending_transactions.forEach(function(tx) {
     //tx.from and address are buffers, so cannot simply do
     //tx.from==address
-    if (tx.from.toString('hex') != address.toString('hex')) return;
+    if (to.hex(tx.from) != to.hex(address)) return;
 
     var pending_nonce = to.number(tx.nonce);
-    console.log('found nonce', pending_nonce);
     //If this is the first queued nonce for this address we found,
     //or it's higher than the previous highest, note it.
     if (nonce===null || pending_nonce > nonce) {
@@ -234,25 +233,22 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
   var sortedByNonce = {};
   for (idx in self.pending_transactions){
     var tx = self.pending_transactions[idx]
-    console.log(tx.from.toString('hex'));
-    if (!sortedByNonce[tx.from.toString('hex')]){
-      sortedByNonce[tx.from.toString('hex')] = [tx];
+    if (!sortedByNonce[to.hex(tx.from)]){
+      sortedByNonce[to.hex(tx.from)] = [tx];
     }else{
-      Array.prototype.push.apply(sortedByNonce[tx.from.toString('hex')], [tx]);
+      Array.prototype.push.apply(sortedByNonce[to.hex(tx.from)], [tx]);
     }
   }
   var priceSort = function(a,b){
-    return parseInt(a.gasPrice.toString('hex'),16)-parseInt(b.gasPrice.toString('hex'),16);
+    return parseInt(to.hex(b.gasPrice),16)-parseInt(to.hex(a.gasPrice),16);
   }
   var nonceSort = function(a,b){
-    return parseInt(b.nonce.toString('hex'),16)-parseInt(a.nonce.toString('hex'),16);
+    return parseInt(to.hex(a.nonce),16) - parseInt(to.hex(b.nonce),16)
   }
 
   //Now sort each address by nonce
   for (address in sortedByNonce){
-    console.log(address);
-    console.log(sortedByNonce[address]);
-    Array.prototype.sort.apply(sortedByNonce[address], nonceSort)
+    Array.prototype.sort.apply(sortedByNonce[address], [nonceSort])
   }
 
   //Initialise a heap, sorted by price, for the head transaction from each account.
@@ -268,8 +264,7 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
   sorted_transactions = [];
   while (heap.size()>0){
     best = heap.pop();
-    console.log('popped with nonce', best.nonce.toString('hex'), ' and gas limit ', best.gasLimit.toString('hex'));
-    if (sortedByNonce[best.from.toString('hex')].length>0){
+    if (sortedByNonce[to.hex(best.from)].length>0){
       //Push on the next transaction from this account
       heap.push(sortedByNonce[address][0]);
       sortedByNonce[address].splice(0,1);

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -280,8 +280,10 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
       generate: true,
     }, function(err, results) {
       //Remove transactions that were added from the pending transactions pool
-      for (idx in successfullyAddedTransactions){
-        self.pending_transactions.splice(idx,1);
+      //We go backwards so that deleting transactions doesn't mess up our
+      //indices
+      for (var i = successfullyAddedTransactions.length-1; i>=0; i--){
+        self.pending_transactions.splice(successfullyAddedTransactions[i],1);
       }
 
       if (err || results.error) {

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -192,18 +192,24 @@ BlockchainDouble.prototype.createBlock = function() {
 };
 
 BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
-  var nonce = 0;
+  var nonce = null;
 
   this.pending_transactions.forEach(function(tx) {
-    if (tx.from != address) return;
+    //tx.from and address are buffers, so cannot simply do
+    //tx.from==address
+    if (tx.from.toString('hex') != address.toString('hex')) return;
 
     var pending_nonce = to.number(tx.nonce);
-    if (pending_nonce > nonce) {
+    //If this is the first queued nonce for this address we found,
+    //or it's higher than the previous highest, note it.
+    if (nonce===null || pending_nonce > nonce) {
       nonce = pending_nonce;
     }
   });
 
-  if (nonce > 0) return callback(null, nonce);
+  //If we found a queued transaction nonce, return one higher
+  //than the highest we found
+  if (nonce!=null) return callback(null, nonce+1);
 
   this.stateTrie.get(address, function(err, val) {
     if (err) return callback(err);

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -226,83 +226,137 @@ BlockchainDouble.prototype.queueTransaction = function(tx) {
 BlockchainDouble.prototype.processNextBlock = function(callback) {
   var self = this;
   var block = this.createBlock();
+  var successfullyAddedTransactions = [];
 
-  Array.prototype.push.apply(block.transactions, this.pending_transactions);
+  function tryTransactionIdx(txnumber){
+    Array.prototype.push.apply(block.transactions, [self.pending_transactions[txnumber]]);
+    self._checkpointTrie();
+    self.vm.runBlock({block: block,
+      generate:true}, function(err,results){
+        //Regardless of whether we error'd or not, this was just
+        //an experiment to see if the transaction was good, so
+        //revert the trie
+        //
+        self._revertTrie();
+        if (err || results.error) {
+          err = err || results.error;
 
-  this._checkpointTrie();
+          if (err instanceof Error == false) {
+            err = new Error("VM error: " + err);
+          }
 
-  this.vm.runBlock({
-    block: block,
-    generate: true,
-  }, function(err, results) {
-    self.pending_transactions = [];
+          block.transactions.pop(); //Remove the bad transaction from the block
 
-    if (err || results.error) {
-      err = err || results.error;
+          //If this is the first queued transaction, it must be bad
+          //so throw after deleting it from pending
+          //transactions (transactions we don't try first might just not
+          //be able to fit in the current block due to gas);
 
-      if (err instanceof Error == false) {
-        err = new Error("VM error: " + err);
-      }
-
-      self._revertTrie();
-      //block.transactions.pop();
-
-      callback(err);
-      return;
-    }
-
-
-    var logs = [];
-    var receipts = [];
-
-    var totalBlockGasUsage = 0;
-
-    results.results.forEach(function(result) {
-      totalBlockGasUsage += to.number(result.gasUsed);
-    });
-
-    block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
-
-    for (var v = 0; v < results.receipts.length; v++) {
-      var result = results.results[v];
-      var receipt = results.receipts[v];
-      var tx = block.transactions[v];
-      var tx_hash = tx.hash();
-      var tx_logs = [];
-
-      for (var i = 0; i < receipt.logs.length; i++) {
-        var log = receipt.logs[i];
-        var address = to.hex(log[0]);
-        var topics = []
-
-        for (var j = 0; j < log[1].length; j++) {
-          topics.push(to.hex(log[1][j]));
+          if (txnumber===0){
+            self.pending_transactions.splice(0,1);
+            callback(err);
+            return;
+          }
+        }else{
+          //Otherwise, went in the block okay.
+          //Note that we want to remove it from our transaction pool
+          Array.prototype.push.apply(successfullyAddedTransactions, [txnumber]);
         }
 
-        var data = to.hex(log[2]);
+        if (txnumber < self.pending_transactions.length-1){
+          return tryTransactionIdx(txnumber+1);
+        }else{
+          //Otherwise, mine the block as we've tried all the
+          //pending transactions for now
+          mineBlock();
+        }
+      });
+  }
 
-        var log = new Log({
-          logIndex: to.hex(i),
-          transactionIndex: to.hex(v),
-          transactionHash: tx_hash,
-          block: block,
-          address: address,
-          data: data,
-          topics: topics,
-          type: "mined"
-        });
-
-        logs.push(log);
-        tx_logs.push(log);
+  function mineBlock(){
+    self._checkpointTrie();
+    self.vm.runBlock({
+      block: block,
+      generate: true,
+    }, function(err, results) {
+      //Remove transactions that were added from the pending transactions pool
+      for (idx in successfullyAddedTransactions){
+        self.pending_transactions.splice(idx,1);
       }
 
-      receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
-    }
+      if (err || results.error) {
+        //This is surprising, because we just tried this block and
+        //then reverted it after it was successful. But you can never be too
+        //careful...
+        err = err || results.error;
 
-    self.putBlock(block, logs, receipts);
+        if (err instanceof Error == false) {
+          err = new Error("VM error: " + err);
+        }
 
-    callback(null, results);
-  });
+        self._revertTrie();
+
+        callback(err);
+        return;
+      }
+
+
+      var logs = [];
+      var receipts = [];
+
+      var totalBlockGasUsage = 0;
+
+      results.results.forEach(function(result) {
+        totalBlockGasUsage += to.number(result.gasUsed);
+      });
+
+      block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
+
+      for (var v = 0; v < results.receipts.length; v++) {
+        var result = results.results[v];
+        var receipt = results.receipts[v];
+        var tx = block.transactions[v];
+        var tx_hash = tx.hash();
+        var tx_logs = [];
+
+        for (var i = 0; i < receipt.logs.length; i++) {
+          var log = receipt.logs[i];
+          var address = to.hex(log[0]);
+          var topics = []
+
+          for (var j = 0; j < log[1].length; j++) {
+            topics.push(to.hex(log[1][j]));
+          }
+
+          var data = to.hex(log[2]);
+
+          var log = new Log({
+            logIndex: to.hex(i),
+            transactionIndex: to.hex(v),
+            transactionHash: tx_hash,
+            block: block,
+            address: address,
+            data: data,
+            topics: topics,
+            type: "mined"
+          });
+
+          logs.push(log);
+          tx_logs.push(log);
+        }
+
+        receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
+      }
+
+      self.putBlock(block, logs, receipts);
+      callback(null, results);
+    });
+  }
+  if (self.pending_transactions.length > 0){
+    tryTransactionIdx(0);
+  } else {
+    mineBlock();
+  }
 };
 
 BlockchainDouble.prototype.getAccount = function(address, number, callback) {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -51,6 +51,8 @@ StateManager = function(options) {
   if (options.gasPrice) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
+
+  this.no_mine_after_transaction = options.no_mine_after_transaction;
 }
 
 StateManager.prototype.initialize = function(options, callback) {
@@ -338,10 +340,13 @@ StateManager.prototype.processTransaction = function(from, tx, callback) {
 
   this.blockchain.queueTransaction(tx);
 
+  var tx_hash = to.hex(tx.hash());
+  if (this.no_mine_after_transaction){
+    return callback(null, tx_hash);
+  }
+
   this.blockchain.processNextBlock(function(err, results) {
     if (err) return callback(err);
-
-    var tx_hash = to.hex(tx.hash());
 
     var result = results.results[0];
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -52,7 +52,7 @@ StateManager = function(options) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
 
-  this.no_mine_after_transaction = false;
+  this.is_mining = true;
 }
 
 StateManager.prototype.initialize = function(options, callback) {
@@ -255,6 +255,11 @@ StateManager.prototype.queueTransaction = function(method, tx_params, callback) 
     return callback(new Error("Invalid to address"));
   }
 
+  // If the transaction has a higher gas limit than the block gas limit, error.
+  if (to.number(rawTx.gasLimit) > to.number(this.blockchain.gasLimit)) {
+    return callback(new Error("Exceeds block gas limit"));
+  }
+
   // Get the nonce for this address, taking account any transactions already queued.
   var self = this;
   var address = utils.toBuffer(tx_params.from);
@@ -358,27 +363,27 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
   });
 }
 
-StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback){
+StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback) {
   var self = this;
   var prevPending = self.blockchain.pending_transactions.length;
-  if (prevPending===0){
+  if (prevPending === 0){
     return callback();
   }
-  self.blockchain.processNextBlock(function(err,results){
+  self.blockchain.processNextBlock(function(err, results){
     if (err) return callback(err);
 
     var result = results.results[0];
     if (result.vm.exception != 1) {
       return callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
-    }else if (self.blockchain.pending_transactions.length!==prevPending && self.blockchain.pending_transactions.length!==0){
-      //We added some transactions, and there are more to go
+    }else if (self.blockchain.pending_transactions.length !== prevPending && self.blockchain.pending_transactions.length !==0 ){
+      // We added some transactions, and there are more to go
       return self.processBlocksUntilNoMoreTransactionsAdded(callback);
     }else{
-      //No more pending transactions - I guess we're done here.
+      // No more pending transactions - I guess we're done here.
       callback();
     }
   })
-}
+};
 
 StateManager.prototype.processTransaction = function(from, tx, callback) {
   var self = this;
@@ -387,7 +392,7 @@ StateManager.prototype.processTransaction = function(from, tx, callback) {
 
   var tx_hash = to.hex(tx.hash());
 
-  if (self.no_mine_after_transaction){
+  if (self.is_mining == false){
     return callback(null, tx_hash);
   }
 
@@ -487,6 +492,16 @@ StateManager.prototype.hasContractCode = function(address, callback) {
       callback( null, true );
     }
   });
+}
+
+StateManager.prototype.startMining = function(callback) {
+  this.is_mining = true;
+  this.processBlocksUntilNoMoreTransactionsAdded(callback);
+};
+
+StateManager.prototype.stopMining = function(callback) {
+  this.is_mining = false;
+  callback();
 }
 
 module.exports = StateManager;

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -52,7 +52,7 @@ StateManager = function(options) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
 
-  this.no_mine_after_transaction = options.no_mine_after_transaction;
+  this.no_mine_after_transaction = false;
 }
 
 StateManager.prototype.initialize = function(options, callback) {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -361,6 +361,9 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
 StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback){
   var self = this;
   var prevPending = self.blockchain.pending_transactions.length;
+  if (prevPending===0){
+    return callback();
+  }
   self.blockchain.processNextBlock(function(err,results){
     if (err) return callback(err);
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -335,46 +335,66 @@ StateManager.prototype.sign = function(address, dataToSign) {
   return utils.addHexPrefix(r.concat(s, v));
 };
 
-StateManager.prototype.processTransaction = function(from, tx, callback) {
+StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
   var self = this;
 
-  this.blockchain.queueTransaction(tx);
+  self.blockchain.getTransactionReceipt(tx_hash, function(err, receipt) {
+    var block = self.blockchain.latestBlock();
+    receipt = receipt.toJSON();
 
-  var tx_hash = to.hex(tx.hash());
-  if (this.no_mine_after_transaction){
-    return callback(null, tx_hash);
-  }
+    self.logger.log("");
+    self.logger.log("  Transaction: " + tx_hash);
 
-  this.blockchain.processNextBlock(function(err, results) {
+    if (receipt.contractAddress != null) {
+      self.logger.log("  Contract created: " + receipt.contractAddress);
+    }
+
+    self.logger.log("  Gas usage: " + receipt.gasUsed);
+    self.logger.log("  Block Number: " + receipt.blockNumber);
+    self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
+    self.logger.log("");
+
+    callback(null, tx_hash);
+  });
+}
+
+StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback){
+  var self = this;
+  var prevPending = self.blockchain.pending_transactions.length;
+  self.blockchain.processNextBlock(function(err,results){
     if (err) return callback(err);
 
     var result = results.results[0];
-
     if (result.vm.exception != 1) {
-      callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
-      return;
+      return callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
+    }else if (self.blockchain.pending_transactions.length!==prevPending && self.blockchain.pending_transactions.length!==0){
+      //We added some transactions, and there are more to go
+      return self.processBlocksUntilNoMoreTransactionsAdded(callback);
+    }else{
+      //No more pending transactions - I guess we're done here.
+      callback();
     }
+  })
+}
 
-    var block = self.blockchain.latestBlock();
+StateManager.prototype.processTransaction = function(from, tx, callback) {
+  var self = this;
 
-    self.blockchain.getTransactionReceipt(tx_hash, function(err, receipt) {
-      receipt = receipt.toJSON();
+  self.blockchain.queueTransaction(tx);
 
-      self.logger.log("");
-      self.logger.log("  Transaction: " + tx_hash);
+  var tx_hash = to.hex(tx.hash());
 
-      if (receipt.contractAddress != null) {
-        self.logger.log("  Contract created: " + receipt.contractAddress);
-      }
+  if (self.no_mine_after_transaction){
+    return callback(null, tx_hash);
+  }
 
-      self.logger.log("  Gas usage: " + receipt.gasUsed);
-      self.logger.log("  Block Number: " + receipt.blockNumber);
-      self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
-      self.logger.log("");
+  self.processBlocksUntilNoMoreTransactionsAdded(function(err, results){
+    if (err){
+      return callback(err)
+    }
+    self.printTransactionReceipt(tx_hash, callback);
+  })
 
-      callback(null, tx_hash);
-    });
-  });
 };
 
 StateManager.prototype.getTransactionReceipt = function(hash, callback) {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -245,16 +245,16 @@ GethApiDouble.prototype.net_version = function(callback) {
 };
 
 GethApiDouble.prototype.miner_start = function(threads, callback) {
-  this.state.no_mine_after_transaction = false;
-  this.state.processBlocksUntilNoMoreTransactionsAdded(function(err) {
+  this.state.startMining(function(err) {
     callback(err, true);
   });
-}
+};
 
 GethApiDouble.prototype.miner_stop = function(callback) {
-  this.state.no_mine_after_transaction = true;
-  callback(null, true);
-}
+  this.state.stopMining(function(err) {
+    callback(err, true);
+  });
+};
 
 /* Functions for testing purposes only. */
 

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -251,7 +251,7 @@ GethApiDouble.prototype.miner_start = function(threads, callback) {
   });
 }
 
-GethApiDouble.prototype.miner_stop = function(threads, callback) {
+GethApiDouble.prototype.miner_stop = function(callback) {
   this.state.no_mine_after_transaction = true;
   callback(null, true);
 }

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -244,6 +244,19 @@ GethApiDouble.prototype.net_version = function(callback) {
   callback(null, this.state.net_version + "");
 };
 
+GethApiDouble.prototype.miner_start = function(threads, callback) {
+  this.state.no_mine_after_transaction = false;
+  //Mine [TODO: if we have pending transactions?]
+  this.state.blockchain.processNextBlock(function(err) {
+    callback(err, true);
+  });
+}
+
+GethApiDouble.prototype.miner_stop = function(threads, callback) {
+  this.state.no_mine_after_transaction = true;
+  callback(null, true);
+}
+
 /* Functions for testing purposes only. */
 
 GethApiDouble.prototype.evm_snapshot = function(callback) {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -246,8 +246,7 @@ GethApiDouble.prototype.net_version = function(callback) {
 
 GethApiDouble.prototype.miner_start = function(threads, callback) {
   this.state.no_mine_after_transaction = false;
-  //Mine [TODO: if we have pending transactions?]
-  this.state.blockchain.processNextBlock(function(err) {
+  this.state.processBlocksUntilNoMoreTransactionsAdded(function(err) {
     callback(err, true);
   });
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ethereumjs-vm": "^1.3.0",
     "ethereumjs-wallet": "^0.6.0",
     "fake-merkle-patricia-tree": "^1.0.1",
+    "heap": "^0.2.6",
     "merkle-patricia-tree": "^2.1.2",
     "seedrandom": "^2.4.2",
     "shelljs": "^0.6.0",

--- a/test/gas.js
+++ b/test/gas.js
@@ -20,7 +20,7 @@ describe("Gas Estimation", function() {
   });
 
   before("compile source", function(done) {
-    this.timeout(5000);
+    this.timeout(10000);
     web3.eth.compile.solidity(source, function(err, result) {
       if (err) return done(err);
 

--- a/test/mining.js
+++ b/test/mining.js
@@ -1,0 +1,172 @@
+var Web3 = require('web3');
+var TestRPC = require("../index.js");
+var assert = require('assert');
+var to = require("../lib/utils/to.js");
+
+describe("Block Processing", function() {
+  var web3 = new Web3(TestRPC.provider());
+  var accounts;
+
+  // Everything's a Promise to add in readibility.
+
+  function getBlockNumber() {
+    return new Promise(function(accept, reject) {
+      web3.eth.getBlockNumber(function(err, number) {
+        if (err) return reject(err);
+        accept(to.number(number));
+      });
+    });
+  };
+
+  function startMining() {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_start",
+        params: [1],
+        id: new Date().getTime()
+      }, function(err) {
+        if (err) return reject(err);
+        accept();
+      });
+    });
+  }
+
+  function stopMining() {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+        id: new Date().getTime()
+      }, function(err) {
+        if (err) return reject(err);
+        accept();
+      });
+    });
+  }
+
+  function queueTransaction(from, to, gasLimit, value) {
+    return new Promise(function(accept, reject) {
+      web3.eth.sendTransaction({
+        from: from,
+        to: to,
+        gas: gasLimit,
+        value: value
+      }, function(err, tx) {
+        if (err) return reject(err);
+        accept(tx);
+      });
+    })
+  }
+
+  function getReceipt(tx) {
+    return new Promise(function(accept, reject) {
+      web3.eth.getTransactionReceipt(tx, function(err, result) {
+        if (err) return reject(err);
+        accept(result);
+      });
+    });
+  };
+
+  before(function(done) {
+    web3.eth.getAccounts(function(err, accs) {
+      if (err) return done(err);
+      accounts = accs;
+      done();
+    });
+  });
+
+  it("should mine a single block with two queued transactions", function() {
+    var tx1, tx2, blockNumber;
+
+    return stopMining().then(function() {
+      return getBlockNumber();
+    }).then(function(number) {
+      blockNumber = number;
+      return queueTransaction(accounts[0], accounts[1], 90000, web3.toWei(2, "Ether"));
+    }).then(function(tx) {
+      tx1 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return queueTransaction(accounts[0], accounts[1], 90000, web3.toWei(3, "Ether"));
+    }).then(function(tx) {
+      tx2 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return startMining();
+    }).then(function() {
+      return Promise.all([getReceipt(tx1), getReceipt(tx2)]);
+    }).then(function(receipts) {
+      assert.equal(receipts.length, 2);
+      assert.notEqual(receipts[0], null);
+      assert.equal(receipts[0].transactionHash, tx1);
+      assert.notEqual(receipts[1], null);
+      assert.equal(receipts[1].transactionHash, tx2);
+
+      return getBlockNumber();
+    }).then(function(number) {
+      assert.equal(number, blockNumber + 1);
+    });
+  });
+
+  it("should mine two blocks when two queued transactions won't fit into a single block", function() {
+    // This is a very similar test to the above, except the gas limits are much higher
+    // per transaction. This means the TestRPC will react differently and process
+    // each transaction it its own block.
+
+    var tx1, tx2, blockNumber;
+
+    return stopMining().then(function() {
+      return getBlockNumber();
+    }).then(function(number) {
+      blockNumber = number;
+      return queueTransaction(accounts[0], accounts[1], 4000000, web3.toWei(2, "Ether"));
+    }).then(function(tx) {
+      tx1 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return queueTransaction(accounts[0], accounts[1], 4000000, web3.toWei(3, "Ether"));
+    }).then(function(tx) {
+      tx2 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return startMining();
+    }).then(function() {
+      return Promise.all([getReceipt(tx1), getReceipt(tx2)]);
+    }).then(function(receipts) {
+      assert.equal(receipts.length, 2);
+      assert.notEqual(receipts[0], null);
+      assert.equal(receipts[0].transactionHash, tx1);
+      assert.notEqual(receipts[1], null);
+      assert.equal(receipts[1].transactionHash, tx2);
+
+      return getBlockNumber();
+    }).then(function(number) {
+      assert.equal(number, blockNumber + 2);
+    });
+  });
+
+  it("should error if queued transaction exceeds the block gas limit", function(done) {
+    return stopMining().then(function() {
+      return queueTransaction(accounts[0], accounts[1], 5000000, web3.toWei(2, "Ether"));
+    }).then(function(tx) {
+      // It should never get here.
+      return done(new Error("Transaction was processed without erroring; gas limit should have been too high"));
+    }).catch(function(err) {
+      // We caught an error like we expected. Ensure it's the right error, or rethrow.
+      if (err.message.toLowerCase().indexOf("exceeds block gas limit") < 0) {
+        return done(new Error("Did not receive expected error; instead received: " + err));
+      }
+
+      done();
+    });
+  });
+});

--- a/test/queuedTransactions.js
+++ b/test/queuedTransactions.js
@@ -1,0 +1,91 @@
+var Web3 = require('web3');
+var TestRPC = require("../index.js");
+var assert = require('assert');
+
+
+
+var accounts;
+var web3 = new Web3(TestRPC.provider());
+
+before(function(done) {
+  web3.eth.getAccounts(function(err, accs) {
+    if (err) return done(err);
+
+    accounts = accs;
+    done();
+  });
+});
+
+beforeEach(function(done){
+  web3.currentProvider.sendAsync({
+    jsonrpc: "2.0",
+    method: "miner_stop",
+  }, done)
+});
+
+afterEach(function(done){
+  web3.currentProvider.sendAsync({
+    jsonrpc: "2.0",
+    method: "miner_start",
+    params: [1]
+  }, done)
+});
+
+
+describe("Ordering transactions", function() {
+  it("should order queued transactions correctly by nonce before adding to the block", function(done) {
+    var tx_data = {}
+    tx_data.to = accounts[1];
+    tx_data.from = accounts[0];
+    tx_data.value = 0x1;
+    tx_data.nonce = 0;
+    tx_data.gas = 21000;
+    web3.eth.sendTransaction(tx_data, function(err, tx) {
+      if (err){return done(err)}
+      tx_data.nonce=1;
+      web3.eth.sendTransaction(tx_data, function(err, tx){
+        if (err){return done(err)}
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,tx){
+          web3.eth.getBlock("latest", function(err, block) {
+            if (err) return done(err);
+            assert.equal(block.transactions.length, 2, "Latest block should have two transactions");
+            done();
+          });
+        })
+      })
+    })
+  });
+  it("should order queued transactions correctly by price before adding to the block", function(done) {
+    var tx_data = {}
+    tx_data.to = accounts[1];
+    tx_data.from = accounts[0];
+    tx_data.value = 0x1;
+    tx_data.gas = 21000;
+    tx_data.gasPrice = 0x1
+    web3.eth.sendTransaction(tx_data, function(err, tx) {
+      if (err){return done(err)}
+      tx_data.gasPrice=2;
+      tx_data.from = accounts[1];
+      web3.eth.sendTransaction(tx_data, function(err, tx){
+        if (err){return done(err)}
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,tx){
+          web3.eth.getBlock("latest", function(err, block) {
+            if (err) return done(err);
+            assert.equal(block.transactions.length, 2, "Latest block should have two transactions");
+            assert.equal(block.transactions[0].gasPrice.toNumber(),2)
+            assert.equal(block.transactions[1].gasPrice.toNumber(),1)
+            done();
+          });
+        })
+      })
+    })
+  });
+});

--- a/test/queuedTransactions.js
+++ b/test/queuedTransactions.js
@@ -2,37 +2,34 @@ var Web3 = require('web3');
 var TestRPC = require("../index.js");
 var assert = require('assert');
 
-
-
-var accounts;
-var web3 = new Web3(TestRPC.provider());
-
-before(function(done) {
-  web3.eth.getAccounts(function(err, accs) {
-    if (err) return done(err);
-
-    accounts = accs;
-    done();
-  });
-});
-
-beforeEach(function(done){
-  web3.currentProvider.sendAsync({
-    jsonrpc: "2.0",
-    method: "miner_stop",
-  }, done)
-});
-
-afterEach(function(done){
-  web3.currentProvider.sendAsync({
-    jsonrpc: "2.0",
-    method: "miner_start",
-    params: [1]
-  }, done)
-});
-
-
 describe("Ordering transactions", function() {
+  var accounts;
+  var web3 = new Web3(TestRPC.provider());
+
+  before(function(done) {
+    web3.eth.getAccounts(function(err, accs) {
+      if (err) return done(err);
+
+      accounts = accs;
+      done();
+    });
+  });
+
+  beforeEach(function(done){
+    web3.currentProvider.sendAsync({
+      jsonrpc: "2.0",
+      method: "miner_stop",
+    }, done)
+  });
+
+  afterEach(function(done){
+    web3.currentProvider.sendAsync({
+      jsonrpc: "2.0",
+      method: "miner_start",
+      params: [1]
+    }, done)
+  });
+
   it("should order queued transactions correctly by nonce before adding to the block", function(done) {
     var tx_data = {}
     tx_data.to = accounts[1];
@@ -59,6 +56,7 @@ describe("Ordering transactions", function() {
       })
     })
   });
+  
   it("should order queued transactions correctly by price before adding to the block", function(done) {
     var tx_data = {}
     tx_data.to = accounts[1];

--- a/test/requests.js
+++ b/test/requests.js
@@ -611,7 +611,6 @@ var tests = function(web3) {
           tx_data.from = accounts[0];
           tx_data.value = 0x1;
 
-
           web3.eth.sendTransaction(tx_data, function(err, tx) {
             if (err) return done(err);
             //Check the receipt

--- a/test/requests.js
+++ b/test/requests.js
@@ -563,6 +563,69 @@ var tests = function(web3) {
     });
   });
 
+  describe("miner_stop", function(){
+    it("should stop mining", function(done){
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+      }, function(err,result){
+        var tx_data = {}
+        tx_data.to = accounts[1];
+        tx_data.from = accounts[0];
+        tx_data.value = 0x1;
+
+        web3.eth.sendTransaction(tx_data, function(err, tx) {
+          if (err) return done(err);
+
+          web3.eth.getTransactionReceipt(tx, function(err, receipt) {
+            if (err) return done(err);
+
+            assert.equal(receipt, null);
+            web3.currentProvider.sendAsync({
+              jsonrpc: "2.0",
+              method: "miner_start",
+              params: [1]
+            }, function(err, result){
+              if (err) return done(err);
+              done();
+            })
+          });
+        });
+      })
+    })
+  });
+
+  describe("miner_start", function(){
+    it("should start mining", function(done){
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+      }, function(err,result){
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,result){
+          var tx_data = {}
+          tx_data.to = accounts[1];
+          tx_data.from = accounts[0];
+          tx_data.value = 0x1;
+
+
+          web3.eth.sendTransaction(tx_data, function(err, tx) {
+            if (err) return done(err);
+            //Check the receipt
+            web3.eth.getTransactionReceipt(tx, function(err, receipt) {
+              if (err) return done(err);
+              assert.notEqual(receipt, null); //i.e. receipt exists, so transaction was mined
+              done();
+            });
+          });
+        })
+      })
+    })
+  });
+
   describe("web3_sha3", function() {
     it("should hash the given input", function(done) {
       var input = "Tim is a swell guy.";


### PR DESCRIPTION
I can't quite figure out how to compare my changes with the changes on #155. However, here's the gist:
- Performed some stylistic changes
- Removed preprocessing of transactions, so transactions are only processed once
- Stopped checkpointing the trie - this will leave failed transactions on the chain like all other blockchains (i.e., geth, etc). This is possibly controversial, but it removes the need to preprocess transactions at all.
- Refactored block processing logic such that block processing now only tries to grab as many transactions as will fit in the block, based on the transactions' gas limit. This processing could be smarter to stuff blocks even fuller, but this is good for now.
- Added a check when transactions are queued to ensure their gas limit doesn't exceed the block gas limit.
- Refactored `no_mine_after_transaction` flag to be called `is_mining`, and gave it a `StateManager.startMining()` and a `StateManager.stopMining()` interface.
- Edited queuedTransactions.js so that the `before` steps were within the `describe` block (minor change)
- Added three more tests in mining.js to ensure block processing works like we expect.
