### PR TITLE
Implement rpc_modules for `geth attach` compatibility.

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -244,6 +244,11 @@ GethApiDouble.prototype.net_version = function(callback) {
   callback(null, this.state.net_version + "");
 };
 
+GethApiDouble.prototype.rpc_modules = function(callback) {
+  // returns the availible api modules and versions
+  callback(null, {"eth":"1.0","net":"1.0","rpc":"1.0","web3":"1.0","evm":"1.0"});
+};
+
 /* Functions for testing purposes only. */
 
 GethApiDouble.prototype.evm_snapshot = function(callback) {


### PR DESCRIPTION
Geth provides a nice console, with web3 provided, via the `geth attach` command. Currently, this command fails with the message 

> Fatal: Failed to start the JavaScript console: api modules: unable to retrieve modules

because testrpc does not implement the `rpc_modules` method. This PR fixes this, and now a geth console may be attached to a testrpc instance with 

```
geth attach http://localhost:8545
```
