### PR TITLE
Fixed --accounts option

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -58,7 +58,7 @@ StateManager.prototype.initialize = function(options, callback) {
 
   var accounts = [];
 
-  var total_accounts = this.total_accounts || 10;
+  var total_accounts = options.total_accounts || 10;
 
   if (options.accounts) {
     accounts = options.accounts.map(this.createAccount.bind(this));


### PR DESCRIPTION
Fix for an error in the argument parsing that makes it impossible to generate any other number of accounts than 10.
