### PR TITLE
3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ TODO
 *.log
 .eslintrc.js
 .tern-project
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"total_accounts"`: `number` - Number of accounts to generate at startup.
 * `"fork"`: `string` - Same as `--fork` option above.
 * `"time"`: `Date` - Date that the first block should start. Use this feature, along with the `evm_increaseTime` method to test time-dependent code.
+* `"locked"`: `boolean` - whether or not accounts are locked by default.
+* `"unlocked_accounts"`: `Array` - array of addresses or address indexes specifying which accounts should be unlocked.
 
 # IMPLEMENTED METHODS
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Options:
 * `-a` or `--accounts`: Specify the number of accounts to generate at startup.
 * `-b` or `--blocktime`: Specify blocktime in seconds for automatic mining. Default is 0 and no auto-mining.
 * `-d` or `--deterministic`: Generate deterministic addresses based on a pre-defined mnemonic.
+* `-n` or `--secure`: Lock available accounts by default (good for third party transaction signing)
 * `-m` or `--mnemonic`: Use a specific HD wallet mnemonic to generate initial addresses.
 * `-p` or `--port`: Port number to listen on. Defaults to 8545.
 * `-h` or `--hostname`: Hostname to listen on. Defaults to Node's `server.listen()` [default](https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback).
@@ -38,15 +39,31 @@ Options:
 * `-f` or `--fork`: Fork from another currently running Ethereum client at a given block. Input should be the HTTP location and port of the other client, e.g. `http://localhost:8545`. You can optionally specify the block to fork from using an `@` sign: `http://localhost:8545@1599200`.
 * `--debug`: Output VM opcodes for debugging
 
-You can also specify `--account=...` (no 's') any number of times passing arbitrary private keys and their associated balances to generate initial addresses:
+Special Options:
 
-```
-$ testrpc --account="<privatekey>,balance" [--account="<privatekey>,balance"]
-```
+* `--account`: Specify `--account=...` (no 's') any number of times passing arbitrary private keys and their associated balances to generate initial addresses:
 
-Note that private keys are 64 characters long, and must be input as a 0x-prefixed hex string. Balance can either be input as an integer or 0x-prefixed hex value specifying the amount of wei in that account.
+  ```
+  $ testrpc --account="<privatekey>,balance" [--account="<privatekey>,balance"]
+  ```
 
-An HD wallet will not be created for you when using `--account`.
+  Note that private keys are 64 characters long, and must be input as a 0x-prefixed hex string. Balance can either be input as an integer or 0x-prefixed hex value specifying the amount of wei in that account.
+
+  An HD wallet will not be created for you when using `--account`.
+
+* `-u` or `--unlock`: Specify `--unlock ...` any number of times passing either an address or an account index to unlock specific accounts. When used in conjunction with `--secure`, `--unlock` will override the locked state of specified accounts.
+
+  ```
+  $ testrpc --secure --unlock "0x1234..." --unlock "0xabcd..."
+  ```
+
+  You can also specify a number, unlocking accounts by their index:
+
+  ```
+  $ testrpc --secure -u 0 -u 1
+  ```
+
+  This feature can also be used to impersonate accounts and unlock addresses you wouldn't otherwise have access to. When used with the `--fork` feature, you can use the TestRPC to make transactions as any address on the blockchain, which is very useful for testing and dynamic analysis.
 
 ##### Library
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ The RPC methods currently implemented are:
 * `net_listening`
 * `net_peerCount`
 * `net_version`
+* `miner_start`
+* `miner_stop`
+* `rpc_modules`
 * `web3_clientVersion`
 * `web3_sha3`
 
@@ -142,7 +145,7 @@ There’s also special non-standard methods that aren’t included within the or
 * `evm_snapshot` : Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the integer id of the snapshot created.
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.
 * `evm_increaseTime` : Jump forward in time. Takes one parameter, which is the amount of time to increase in seconds. Returns the total time adjustment, in seconds.
-* `evm_mine` : Force a block to be mined. Takes no parameters.
+* `evm_mine` : Force a block to be mined. Takes no parameters. Mines a block independent of whether or not mining is started or stopped.
 
 # TESTING
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The RPC methods currently implemented are:
 * `eth_getLogs`
 * `eth_getStorageAt`
 * `eth_getTransactionByHash`
+* `eth_getTransactionByBlockHashAndIndex`
+* `eth_getTransactionByBlockNumberAndIndex`
 * `eth_getTransactionCount`
 * `eth_getTransactionReceipt`
 * `eth_hashrate`

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -46,7 +46,6 @@ var options = {
   fork: argv.f || argv.fork || false,
   network_id: argv.i || argv.networkId,
   verbose: argv.v || argv.verbose,
-  no_mine_after_transaction: argv.n || argv.noMineAfterTransaction || false,
   logger: console
 }
 

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -46,6 +46,7 @@ var options = {
   fork: argv.f || argv.fork || false,
   network_id: argv.i || argv.networkId,
   verbose: argv.v || argv.verbose,
+  no_mine_after_transaction: argv.n || argv.noMineAfterTransaction || false,
   logger: console
 }
 

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -59,7 +59,7 @@ var options = {
   fork: argv.f || argv.fork || false,
   network_id: argv.i || argv.networkId,
   verbose: argv.v || argv.verbose,
-  locked: argv.n || argv.secure || false,
+  secure: argv.n || argv.secure || false,
   logger: console
 }
 

--- a/bin/testrpc
+++ b/bin/testrpc
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
-var argv = require('yargs').argv;
+var yargs = require('yargs');
 var TestRPC = require('..');
 var pkg = require("../package.json");
 var util = require("ethereumjs-util");
 var URL = require("url");
 var Web3 = require("web3");
 var web3 = new Web3(); // Used only for its BigNumber library.
+
+yargs
+.option("unlock", {
+  type: "string",
+  alias: "u"
+});
+
+var argv = yargs.argv;
 
 function parseAccounts(accounts) {
   function splitAccount(account) {
@@ -32,6 +40,10 @@ if (argv.d || argv.deterministic) {
   argv.s = "TestRPC is awesome!";
 }
 
+if (typeof argv.unlock == "string") {
+  argv.unlock = [argv.unlock];
+}
+
 var options = {
   port: argv.p || argv.port || "8545",
   hostname: argv.h || argv.hostname,
@@ -43,9 +55,11 @@ var options = {
   gasPrice: argv.g || argv.gasPrice,
   gasLimit: argv.l || argv.gasLimit,
   accounts: parseAccounts(argv.account),
+  unlocked_accounts: argv.unlock,
   fork: argv.f || argv.fork || false,
   network_id: argv.i || argv.networkId,
   verbose: argv.v || argv.verbose,
+  locked: argv.n || argv.secure || false,
   logger: console
 }
 
@@ -84,7 +98,13 @@ server.listen(options.port, options.hostname, function(err, state) {
   var addresses = Object.keys(accounts);
 
   addresses.forEach(function(address, index) {
-    console.log("(" + index + ") " + address);
+    var line = "(" + index + ") " + address;
+
+    if (state.isUnlocked(address) == false) {
+      line += " 🔒";
+    }
+
+    console.log(line);
   });
 
   console.log("");

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -9,6 +9,7 @@ var Trie = require("merkle-patricia-tree");
 var Web3 = require("web3");
 var utils = require("ethereumjs-util");
 var async = require('async');
+var Heap = require("heap");
 
 function BlockchainDouble(options) {
   var self = this;
@@ -200,6 +201,7 @@ BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
     if (tx.from.toString('hex') != address.toString('hex')) return;
 
     var pending_nonce = to.number(tx.nonce);
+    console.log('found nonce', pending_nonce);
     //If this is the first queued nonce for this address we found,
     //or it's higher than the previous highest, note it.
     if (nonce===null || pending_nonce > nonce) {
@@ -223,11 +225,67 @@ BlockchainDouble.prototype.queueTransaction = function(tx) {
   this.pending_transactions.push(tx);
 };
 
+BlockchainDouble.prototype.SortByPriceAndNonce = function(){
+  //Sorts transactions like I believe geth does.
+  //See the description of 'SortByPriceAndNonce' at
+  //https://github.com/ethereum/go-ethereum/blob/290e851f57f5d27a1d5f0f7ad784c836e017c337/core/types/transaction.go
+  //
+  var self = this;
+  var sortedByNonce = {};
+  for (idx in self.pending_transactions){
+    var tx = self.pending_transactions[idx]
+    console.log(tx.from.toString('hex'));
+    if (!sortedByNonce[tx.from.toString('hex')]){
+      sortedByNonce[tx.from.toString('hex')] = [tx];
+    }else{
+      Array.prototype.push.apply(sortedByNonce[tx.from.toString('hex')], [tx]);
+    }
+  }
+  var priceSort = function(a,b){
+    return parseInt(a.gasPrice.toString('hex'),16)-parseInt(b.gasPrice.toString('hex'),16);
+  }
+  var nonceSort = function(a,b){
+    return parseInt(b.nonce.toString('hex'),16)-parseInt(a.nonce.toString('hex'),16);
+  }
+
+  //Now sort each address by nonce
+  for (address in sortedByNonce){
+    console.log(address);
+    console.log(sortedByNonce[address]);
+    Array.prototype.sort.apply(sortedByNonce[address], nonceSort)
+  }
+
+  //Initialise a heap, sorted by price, for the head transaction from each account.
+  var heap = new Heap(priceSort);
+  for (address in sortedByNonce){
+    heap.push(sortedByNonce[address][0]);
+    //Remove the transaction from sortedByNonce
+    sortedByNonce[address].splice(0,1);
+  }
+
+  //Now reorder our transactions. Compare the next transactions from each account, and choose
+  //the one with the highest gas price.
+  sorted_transactions = [];
+  while (heap.size()>0){
+    best = heap.pop();
+    console.log('popped with nonce', best.nonce.toString('hex'), ' and gas limit ', best.gasLimit.toString('hex'));
+    if (sortedByNonce[best.from.toString('hex')].length>0){
+      //Push on the next transaction from this account
+      heap.push(sortedByNonce[address][0]);
+      sortedByNonce[address].splice(0,1);
+    }
+    Array.prototype.push.apply(sorted_transactions, [best]);
+  }
+  self.pending_transactions = sorted_transactions;
+}
+
 BlockchainDouble.prototype.processNextBlock = function(callback) {
   var self = this;
   var block = this.createBlock();
   var successfullyAddedTransactions = [];
 
+  //First, sort our transactions like geth does
+  this.SortByPriceAndNonce();
   function tryTransactionIdx(txnumber){
     Array.prototype.push.apply(block.transactions, [self.pending_transactions[txnumber]]);
     self._checkpointTrie();

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -38,8 +38,10 @@ function BlockchainDouble(options) {
     });
   }
 
-  // Homestead Gas Limit is 4712388 / 0x47E7C4
-  this.gasLimit = options.gasLimit || '0x47E7C4';
+  // Homestead block gas limit is 4712388 == 0x47E7C4
+  // Default transaction gas limit is 90000 == 0x15f90
+  this.blockGasLimit = options.gasLimit || "0x47E7C4";
+  this.defaultTransactionGasLimit = '0x15f90';
   this.timeAdjustment = options.timeAdjustment || 0;
 
   if (options.time) {
@@ -177,7 +179,7 @@ BlockchainDouble.prototype.createBlock = function() {
   var block = new Block();
   var parent = this.blocks.length > 0 ? this.latestBlock() : null;
 
-  block.header.gasLimit = this.gasLimit;
+  block.header.gasLimit = this.blockGasLimit;
 
   // Ensure we have the right block number for the VM.
   block.header.number = to.hex(this.getHeight() + 1);
@@ -284,7 +286,7 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
   // Grab only the transactions that can fit within the block
   var currentTransactions = [];
   var totalGasLimit = 0;
-  var maxGasLimit = to.number(block.header.gasLimit);
+  var maxGasLimit = to.number(this.blockGasLimit);
 
   while (this.pending_transactions.length > 0) {
     var tx = this.pending_transactions[0];

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -53,7 +53,7 @@ BlockchainDouble = function(options) {
   this.wallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(this.mnemonic));
   this.wallet_hdpath = "m/44'/60'/0'/0/";
 
-  this.gasPriceVal = '1';
+  this.gasPriceVal = '0x4A817C800'; // 0.02 szabo
 
   if (options.debug == true) {
     this.vm.on('step', function(info){

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -224,18 +224,17 @@ BlockchainDouble.prototype.queueTransaction = function(tx) {
   this.pending_transactions.push(tx);
 };
 
-BlockchainDouble.prototype.SortByPriceAndNonce = function(){
-  //Sorts transactions like I believe geth does.
-  //See the description of 'SortByPriceAndNonce' at
-  //https://github.com/ethereum/go-ethereum/blob/290e851f57f5d27a1d5f0f7ad784c836e017c337/core/types/transaction.go
-  //
+BlockchainDouble.prototype.sortByPriceAndNonce = function() {
+  // Sorts transactions like I believe geth does.
+  // See the description of 'SortByPriceAndNonce' at
+  // https://github.com/ethereum/go-ethereum/blob/290e851f57f5d27a1d5f0f7ad784c836e017c337/core/types/transaction.go
   var self = this;
   var sortedByNonce = {};
   for (idx in self.pending_transactions){
     var tx = self.pending_transactions[idx]
     if (!sortedByNonce[to.hex(tx.from)]){
       sortedByNonce[to.hex(tx.from)] = [tx];
-    }else{
+    } else {
       Array.prototype.push.apply(sortedByNonce[to.hex(tx.from)], [tx]);
     }
   }
@@ -246,12 +245,12 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
     return parseInt(to.hex(a.nonce),16) - parseInt(to.hex(b.nonce),16)
   }
 
-  //Now sort each address by nonce
+  // Now sort each address by nonce
   for (address in sortedByNonce){
     Array.prototype.sort.apply(sortedByNonce[address], [nonceSort])
   }
 
-  //Initialise a heap, sorted by price, for the head transaction from each account.
+  // Initialise a heap, sorted by price, for the head transaction from each account.
   var heap = new Heap(priceSort);
   for (address in sortedByNonce){
     heap.push(sortedByNonce[address][0]);
@@ -259,8 +258,8 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
     sortedByNonce[address].splice(0,1);
   }
 
-  //Now reorder our transactions. Compare the next transactions from each account, and choose
-  //the one with the highest gas price.
+  // Now reorder our transactions. Compare the next transactions from each account, and choose
+  // the one with the highest gas price.
   sorted_transactions = [];
   while (heap.size()>0){
     best = heap.pop();
@@ -272,7 +271,7 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
     Array.prototype.push.apply(sorted_transactions, [best]);
   }
   self.pending_transactions = sorted_transactions;
-}
+};
 
 BlockchainDouble.prototype.processNextBlock = function(callback) {
   var self = this;
@@ -280,138 +279,106 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
   var successfullyAddedTransactions = [];
 
   //First, sort our transactions like geth does
-  this.SortByPriceAndNonce();
-  function tryTransactionIdx(txnumber){
-    Array.prototype.push.apply(block.transactions, [self.pending_transactions[txnumber]]);
-    self._checkpointTrie();
-    self.vm.runBlock({block: block,
-      generate:true}, function(err,results){
-        //Regardless of whether we error'd or not, this was just
-        //an experiment to see if the transaction was good, so
-        //revert the trie
-        //
-        self._revertTrie();
-        if (err || results.error) {
-          err = err || results.error;
+  this.sortByPriceAndNonce();
 
-          if (err instanceof Error == false) {
-            err = new Error("VM error: " + err);
-          }
+  // Grab only the transactions that can fit within the block
+  var currentTransactions = [];
+  var totalGasLimit = 0;
+  var maxGasLimit = to.number(block.header.gasLimit);
 
-          block.transactions.pop(); //Remove the bad transaction from the block
+  while (this.pending_transactions.length > 0) {
+    var tx = this.pending_transactions[0];
+    var gasLimit = to.number(tx.gasLimit);
 
-          //If this is the first queued transaction, it must be bad
-          //so throw after deleting it from pending
-          //transactions (transactions we don't try first might just not
-          //be able to fit in the current block due to gas);
-
-          if (txnumber===0){
-            self.pending_transactions.splice(0,1);
-            callback(err);
-            return;
-          }
-        }else{
-          //Otherwise, went in the block okay.
-          //Note that we want to remove it from our transaction pool
-          Array.prototype.push.apply(successfullyAddedTransactions, [txnumber]);
-        }
-
-        if (txnumber < self.pending_transactions.length-1){
-          return tryTransactionIdx(txnumber+1);
-        }else{
-          //Otherwise, mine the block as we've tried all the
-          //pending transactions for now
-          mineBlock();
-        }
-      });
+    if (totalGasLimit + gasLimit <= maxGasLimit) {
+      totalGasLimit += gasLimit;
+      this.pending_transactions.shift();
+      currentTransactions.push(tx);
+    } else {
+      // Next one won't fit. Break.
+      break;
+    }
   }
 
-  function mineBlock(){
-    self._checkpointTrie();
-    self.vm.runBlock({
-      block: block,
-      generate: true,
-    }, function(err, results) {
-      //Remove transactions that were added from the pending transactions pool
-      //We go backwards so that deleting transactions doesn't mess up our
-      //indices
-      for (var i = successfullyAddedTransactions.length-1; i>=0; i--){
-        self.pending_transactions.splice(successfullyAddedTransactions[i],1);
+  // Remember, we ensured transactions had a valid gas limit when they were queued (in the state manager).
+  // If we run into a case where we can't process any because one is higher than the gas limit,
+  // then it's a serious issue. This should never happen, but let's check anyway.
+  if (currentTransactions.length == 0 && this.pending_transactions.length > 0) {
+    // Error like geth.
+    return callback("Unexpected error condition: next transaction exceeds block gas limit")
+  }
+
+  // Add transactions to the block.
+  Array.prototype.push.apply(block.transactions, currentTransactions);
+
+  //self._checkpointTrie();
+  self.vm.runBlock({
+    block: block,
+    generate: true,
+  }, function(err, results) {
+    if (err || results.error) {
+      err = err || results.error;
+
+      if (err instanceof Error == false) {
+        err = new Error("VM error: " + err);
       }
 
-      if (err || results.error) {
-        //This is surprising, because we just tried this block and
-        //then reverted it after it was successful. But you can never be too
-        //careful...
-        err = err || results.error;
+      //self._revertTrie();
 
-        if (err instanceof Error == false) {
-          err = new Error("VM error: " + err);
-        }
+      callback(err);
+      return;
+    }
 
-        self._revertTrie();
+    var logs = [];
+    var receipts = [];
 
-        callback(err);
-        return;
-      }
+    var totalBlockGasUsage = 0;
 
-
-      var logs = [];
-      var receipts = [];
-
-      var totalBlockGasUsage = 0;
-
-      results.results.forEach(function(result) {
-        totalBlockGasUsage += to.number(result.gasUsed);
-      });
-
-      block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
-
-      for (var v = 0; v < results.receipts.length; v++) {
-        var result = results.results[v];
-        var receipt = results.receipts[v];
-        var tx = block.transactions[v];
-        var tx_hash = tx.hash();
-        var tx_logs = [];
-
-        for (var i = 0; i < receipt.logs.length; i++) {
-          var log = receipt.logs[i];
-          var address = to.hex(log[0]);
-          var topics = []
-
-          for (var j = 0; j < log[1].length; j++) {
-            topics.push(to.hex(log[1][j]));
-          }
-
-          var data = to.hex(log[2]);
-
-          var log = new Log({
-            logIndex: to.hex(i),
-            transactionIndex: to.hex(v),
-            transactionHash: tx_hash,
-            block: block,
-            address: address,
-            data: data,
-            topics: topics,
-            type: "mined"
-          });
-
-          logs.push(log);
-          tx_logs.push(log);
-        }
-
-        receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
-      }
-
-      self.putBlock(block, logs, receipts);
-      callback(null, results);
+    results.results.forEach(function(result) {
+      totalBlockGasUsage += to.number(result.gasUsed);
     });
-  }
-  if (self.pending_transactions.length > 0){
-    tryTransactionIdx(0);
-  } else {
-    mineBlock();
-  }
+
+    block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
+
+    for (var v = 0; v < results.receipts.length; v++) {
+      var result = results.results[v];
+      var receipt = results.receipts[v];
+      var tx = block.transactions[v];
+      var tx_hash = tx.hash();
+      var tx_logs = [];
+
+      for (var i = 0; i < receipt.logs.length; i++) {
+        var log = receipt.logs[i];
+        var address = to.hex(log[0]);
+        var topics = []
+
+        for (var j = 0; j < log[1].length; j++) {
+          topics.push(to.hex(log[1][j]));
+        }
+
+        var data = to.hex(log[2]);
+
+        var log = new Log({
+          logIndex: to.hex(i),
+          transactionIndex: to.hex(v),
+          transactionHash: tx_hash,
+          block: block,
+          address: address,
+          data: data,
+          topics: topics,
+          type: "mined"
+        });
+
+        logs.push(log);
+        tx_logs.push(log);
+      }
+
+      receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
+    }
+
+    self.putBlock(block, logs, receipts);
+    callback(null, results);
+  });
 };
 
 BlockchainDouble.prototype.getAccount = function(address, number, callback) {

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -198,10 +198,9 @@ BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
   this.pending_transactions.forEach(function(tx) {
     //tx.from and address are buffers, so cannot simply do
     //tx.from==address
-    if (tx.from.toString('hex') != address.toString('hex')) return;
+    if (to.hex(tx.from) != to.hex(address)) return;
 
     var pending_nonce = to.number(tx.nonce);
-    console.log('found nonce', pending_nonce);
     //If this is the first queued nonce for this address we found,
     //or it's higher than the previous highest, note it.
     if (nonce===null || pending_nonce > nonce) {
@@ -234,25 +233,22 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
   var sortedByNonce = {};
   for (idx in self.pending_transactions){
     var tx = self.pending_transactions[idx]
-    console.log(tx.from.toString('hex'));
-    if (!sortedByNonce[tx.from.toString('hex')]){
-      sortedByNonce[tx.from.toString('hex')] = [tx];
+    if (!sortedByNonce[to.hex(tx.from)]){
+      sortedByNonce[to.hex(tx.from)] = [tx];
     }else{
-      Array.prototype.push.apply(sortedByNonce[tx.from.toString('hex')], [tx]);
+      Array.prototype.push.apply(sortedByNonce[to.hex(tx.from)], [tx]);
     }
   }
   var priceSort = function(a,b){
-    return parseInt(a.gasPrice.toString('hex'),16)-parseInt(b.gasPrice.toString('hex'),16);
+    return parseInt(to.hex(b.gasPrice),16)-parseInt(to.hex(a.gasPrice),16);
   }
   var nonceSort = function(a,b){
-    return parseInt(b.nonce.toString('hex'),16)-parseInt(a.nonce.toString('hex'),16);
+    return parseInt(to.hex(a.nonce),16) - parseInt(to.hex(b.nonce),16)
   }
 
   //Now sort each address by nonce
   for (address in sortedByNonce){
-    console.log(address);
-    console.log(sortedByNonce[address]);
-    Array.prototype.sort.apply(sortedByNonce[address], nonceSort)
+    Array.prototype.sort.apply(sortedByNonce[address], [nonceSort])
   }
 
   //Initialise a heap, sorted by price, for the head transaction from each account.
@@ -268,8 +264,7 @@ BlockchainDouble.prototype.SortByPriceAndNonce = function(){
   sorted_transactions = [];
   while (heap.size()>0){
     best = heap.pop();
-    console.log('popped with nonce', best.nonce.toString('hex'), ' and gas limit ', best.gasLimit.toString('hex'));
-    if (sortedByNonce[best.from.toString('hex')].length>0){
+    if (sortedByNonce[to.hex(best.from)].length>0){
       //Push on the next transaction from this account
       heap.push(sortedByNonce[address][0]);
       sortedByNonce[address].splice(0,1);

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -280,8 +280,10 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
       generate: true,
     }, function(err, results) {
       //Remove transactions that were added from the pending transactions pool
-      for (idx in successfullyAddedTransactions){
-        self.pending_transactions.splice(idx,1);
+      //We go backwards so that deleting transactions doesn't mess up our
+      //indices
+      for (var i = successfullyAddedTransactions.length-1; i>=0; i--){
+        self.pending_transactions.splice(successfullyAddedTransactions[i],1);
       }
 
       if (err || results.error) {

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -5,6 +5,7 @@ var Block = require('ethereumjs-block');
 var Log = require("./utils/log");
 var Receipt = require("./utils/receipt");
 var VM = require('ethereumjs-vm');
+var RuntimeError = require("./utils/runtimeerror");
 var Trie = require("merkle-patricia-tree");
 var Web3 = require("web3");
 var utils = require("ethereumjs-util");
@@ -169,6 +170,10 @@ BlockchainDouble.prototype.popBlock = function() {
   return block;
 };
 
+BlockchainDouble.prototype.clearPendingTransactions = function() {
+  this.pending_transactions = [];
+};
+
 BlockchainDouble.prototype.putAccount = function(account, address, callback) {
   address = utils.toBuffer(address);
 
@@ -318,16 +323,19 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
     block: block,
     generate: true,
   }, function(err, results) {
-    if (err || results.error) {
-      err = err || results.error;
-
-      if (err instanceof Error == false) {
-        err = new Error("VM error: " + err);
-      }
-
-      callback(err);
-      return;
+    // This is a check that has been in there for awhile. I'm unsure if it's required, but it can't hurt.
+    if (err && err instanceof Error == false) {
+      err = new Error("VM error: " + err);
     }
+
+    // If we're given an error back directly, it's worse than a runtime error. Expose it and get out.
+    if (err) return callback(err);
+
+    // If no error, check for a runtime error. This can return null if no runtime error.
+    err = RuntimeError.fromResults(block.transactions, results);
+
+    // Note, even if we have an error, some transactions may still have succeeded.
+    // Process their logs if so, returning the error at the end.
 
     var logs = [];
     var receipts = [];
@@ -347,37 +355,42 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
       var tx_hash = tx.hash();
       var tx_logs = [];
 
-      for (var i = 0; i < receipt.logs.length; i++) {
-        var log = receipt.logs[i];
-        var address = to.hex(log[0]);
-        var topics = []
+      // Only process the transaction's logs if it didn't error.
+      if (result.vm.exception == 1) {
+        for (var i = 0; i < receipt.logs.length; i++) {
+          var log = receipt.logs[i];
+          var address = to.hex(log[0]);
+          var topics = []
 
-        for (var j = 0; j < log[1].length; j++) {
-          topics.push(to.hex(log[1][j]));
+          for (var j = 0; j < log[1].length; j++) {
+            topics.push(to.hex(log[1][j]));
+          }
+
+          var data = to.hex(log[2]);
+
+          var log = new Log({
+            logIndex: to.hex(i),
+            transactionIndex: to.hex(v),
+            transactionHash: tx_hash,
+            block: block,
+            address: address,
+            data: data,
+            topics: topics,
+            type: "mined"
+          });
+
+          logs.push(log);
+          tx_logs.push(log);
         }
-
-        var data = to.hex(log[2]);
-
-        var log = new Log({
-          logIndex: to.hex(i),
-          transactionIndex: to.hex(v),
-          transactionHash: tx_hash,
-          block: block,
-          address: address,
-          data: data,
-          topics: topics,
-          type: "mined"
-        });
-
-        logs.push(log);
-        tx_logs.push(log);
       }
 
       receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
     }
 
     self.putBlock(block, logs, receipts);
-    callback(null, results);
+
+    // Note we return the err here too, if it exists.
+    callback(err, block.transactions, results);
   });
 };
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -192,18 +192,24 @@ BlockchainDouble.prototype.createBlock = function() {
 };
 
 BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
-  var nonce = 0;
+  var nonce = null;
 
   this.pending_transactions.forEach(function(tx) {
-    if (tx.from != address) return;
+    //tx.from and address are buffers, so cannot simply do
+    //tx.from==address
+    if (tx.from.toString('hex') != address.toString('hex')) return;
 
     var pending_nonce = to.number(tx.nonce);
-    if (pending_nonce > nonce) {
+    //If this is the first queued nonce for this address we found,
+    //or it's higher than the previous highest, note it.
+    if (nonce===null || pending_nonce > nonce) {
       nonce = pending_nonce;
     }
   });
 
-  if (nonce > 0) return callback(null, nonce);
+  //If we found a queued transaction nonce, return one higher
+  //than the highest we found
+  if (nonce!=null) return callback(null, nonce+1);
 
   this.stateTrie.get(address, function(err, val) {
     if (err) return callback(err);

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -311,7 +311,7 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
   // Add transactions to the block.
   Array.prototype.push.apply(block.transactions, currentTransactions);
 
-  //self._checkpointTrie();
+  self._checkpointTrie();
   self.vm.runBlock({
     block: block,
     generate: true,
@@ -322,8 +322,6 @@ BlockchainDouble.prototype.processNextBlock = function(callback) {
       if (err instanceof Error == false) {
         err = new Error("VM error: " + err);
       }
-
-      //self._revertTrie();
 
       callback(err);
       return;

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -226,83 +226,137 @@ BlockchainDouble.prototype.queueTransaction = function(tx) {
 BlockchainDouble.prototype.processNextBlock = function(callback) {
   var self = this;
   var block = this.createBlock();
+  var successfullyAddedTransactions = [];
 
-  Array.prototype.push.apply(block.transactions, this.pending_transactions);
+  function tryTransactionIdx(txnumber){
+    Array.prototype.push.apply(block.transactions, [self.pending_transactions[txnumber]]);
+    self._checkpointTrie();
+    self.vm.runBlock({block: block,
+      generate:true}, function(err,results){
+        //Regardless of whether we error'd or not, this was just
+        //an experiment to see if the transaction was good, so
+        //revert the trie
+        //
+        self._revertTrie();
+        if (err || results.error) {
+          err = err || results.error;
 
-  this._checkpointTrie();
+          if (err instanceof Error == false) {
+            err = new Error("VM error: " + err);
+          }
 
-  this.vm.runBlock({
-    block: block,
-    generate: true,
-  }, function(err, results) {
-    self.pending_transactions = [];
+          block.transactions.pop(); //Remove the bad transaction from the block
 
-    if (err || results.error) {
-      err = err || results.error;
+          //If this is the first queued transaction, it must be bad
+          //so throw after deleting it from pending
+          //transactions (transactions we don't try first might just not
+          //be able to fit in the current block due to gas);
 
-      if (err instanceof Error == false) {
-        err = new Error("VM error: " + err);
-      }
-
-      self._revertTrie();
-      //block.transactions.pop();
-
-      callback(err);
-      return;
-    }
-
-
-    var logs = [];
-    var receipts = [];
-
-    var totalBlockGasUsage = 0;
-
-    results.results.forEach(function(result) {
-      totalBlockGasUsage += to.number(result.gasUsed);
-    });
-
-    block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
-
-    for (var v = 0; v < results.receipts.length; v++) {
-      var result = results.results[v];
-      var receipt = results.receipts[v];
-      var tx = block.transactions[v];
-      var tx_hash = tx.hash();
-      var tx_logs = [];
-
-      for (var i = 0; i < receipt.logs.length; i++) {
-        var log = receipt.logs[i];
-        var address = to.hex(log[0]);
-        var topics = []
-
-        for (var j = 0; j < log[1].length; j++) {
-          topics.push(to.hex(log[1][j]));
+          if (txnumber===0){
+            self.pending_transactions.splice(0,1);
+            callback(err);
+            return;
+          }
+        }else{
+          //Otherwise, went in the block okay.
+          //Note that we want to remove it from our transaction pool
+          Array.prototype.push.apply(successfullyAddedTransactions, [txnumber]);
         }
 
-        var data = to.hex(log[2]);
+        if (txnumber < self.pending_transactions.length-1){
+          return tryTransactionIdx(txnumber+1);
+        }else{
+          //Otherwise, mine the block as we've tried all the
+          //pending transactions for now
+          mineBlock();
+        }
+      });
+  }
 
-        var log = new Log({
-          logIndex: to.hex(i),
-          transactionIndex: to.hex(v),
-          transactionHash: tx_hash,
-          block: block,
-          address: address,
-          data: data,
-          topics: topics,
-          type: "mined"
-        });
-
-        logs.push(log);
-        tx_logs.push(log);
+  function mineBlock(){
+    self._checkpointTrie();
+    self.vm.runBlock({
+      block: block,
+      generate: true,
+    }, function(err, results) {
+      //Remove transactions that were added from the pending transactions pool
+      for (idx in successfullyAddedTransactions){
+        self.pending_transactions.splice(idx,1);
       }
 
-      receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
-    }
+      if (err || results.error) {
+        //This is surprising, because we just tried this block and
+        //then reverted it after it was successful. But you can never be too
+        //careful...
+        err = err || results.error;
 
-    self.putBlock(block, logs, receipts);
+        if (err instanceof Error == false) {
+          err = new Error("VM error: " + err);
+        }
 
-    callback(null, results);
-  });
+        self._revertTrie();
+
+        callback(err);
+        return;
+      }
+
+
+      var logs = [];
+      var receipts = [];
+
+      var totalBlockGasUsage = 0;
+
+      results.results.forEach(function(result) {
+        totalBlockGasUsage += to.number(result.gasUsed);
+      });
+
+      block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
+
+      for (var v = 0; v < results.receipts.length; v++) {
+        var result = results.results[v];
+        var receipt = results.receipts[v];
+        var tx = block.transactions[v];
+        var tx_hash = tx.hash();
+        var tx_logs = [];
+
+        for (var i = 0; i < receipt.logs.length; i++) {
+          var log = receipt.logs[i];
+          var address = to.hex(log[0]);
+          var topics = []
+
+          for (var j = 0; j < log[1].length; j++) {
+            topics.push(to.hex(log[1][j]));
+          }
+
+          var data = to.hex(log[2]);
+
+          var log = new Log({
+            logIndex: to.hex(i),
+            transactionIndex: to.hex(v),
+            transactionHash: tx_hash,
+            block: block,
+            address: address,
+            data: data,
+            topics: topics,
+            type: "mined"
+          });
+
+          logs.push(log);
+          tx_logs.push(log);
+        }
+
+        receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
+      }
+
+      self.putBlock(block, logs, receipts);
+      callback(null, results);
+    });
+  }
+  if (self.pending_transactions.length > 0){
+    tryTransactionIdx(0);
+  } else {
+    mineBlock();
+  }
 };
 
 BlockchainDouble.prototype.getAccount = function(address, number, callback) {

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -125,18 +125,6 @@ var Interface = {
 
     server.provider = provider;
 
-    // // TODO: the reviver option is a hack to allow batches to work with jayson
-    // // it become unecessary after the fix of this bug https://github.com/ethereum/web3.js/issues/345
-    // var server = jayson.server(functions, {
-    //   reviver: function(key, val) {
-    //     if (typeof val === 'object' && val.hasOwnProperty('method') &&
-    //         val.method === 'eth_call' && val.hasOwnProperty('params') &&
-    //         val.params.constructor === Array && val.params.length === 1)
-    //       val.params.push('latest');
-    //     return val;
-    //   }
-    // });
-
     return server;
   },
 

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -128,7 +128,6 @@ var Interface = {
     return server;
   },
 
-  // TODO: Make this class-like to allow for multiple providers?
   provider: function(options) {
     var self = this;
 
@@ -188,19 +187,20 @@ var Interface = {
         //   console.log("payload", JSON.stringify(payload, null, 2));
         // }
 
+        var intermediary = callback;
+
         if (options.verbose) {
           options.logger.log("   > " + JSON.stringify(payload, null, 2).split("\n").join("\n   > "));
 
-          var oldCallback = callback;
-          callback = function(err, result) {
+          intermediary = function(err, result) {
             if (!err) {
               options.logger.log(" <   " + JSON.stringify(result, null, 2).split("\n").join("\n <   "));
             }
-            oldCallback(err, result);
+            callback(err, result);
           };
         }
 
-        engine.sendAsync(payload, callback);
+        engine.sendAsync(payload, intermediary);
       },
       send: function() {
         throw new Error("Synchronous requests are not supported.");

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -51,6 +51,8 @@ StateManager = function(options) {
   if (options.gasPrice) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
+
+  this.no_mine_after_transaction = options.no_mine_after_transaction;
 }
 
 StateManager.prototype.initialize = function(options, callback) {
@@ -338,10 +340,13 @@ StateManager.prototype.processTransaction = function(from, tx, callback) {
 
   this.blockchain.queueTransaction(tx);
 
+  var tx_hash = to.hex(tx.hash());
+  if (this.no_mine_after_transaction){
+    return callback(null, tx_hash);
+  }
+
   this.blockchain.processNextBlock(function(err, results) {
     if (err) return callback(err);
-
-    var tx_hash = to.hex(tx.hash());
 
     var result = results.results[0];
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -52,7 +52,7 @@ StateManager = function(options) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
 
-  this.no_mine_after_transaction = false;
+  this.is_mining = true;
 }
 
 StateManager.prototype.initialize = function(options, callback) {
@@ -255,6 +255,11 @@ StateManager.prototype.queueTransaction = function(method, tx_params, callback) 
     return callback(new Error("Invalid to address"));
   }
 
+  // If the transaction has a higher gas limit than the block gas limit, error.
+  if (to.number(rawTx.gasLimit) > to.number(this.blockchain.gasLimit)) {
+    return callback(new Error("Exceeds block gas limit"));
+  }
+
   // Get the nonce for this address, taking account any transactions already queued.
   var self = this;
   var address = utils.toBuffer(tx_params.from);
@@ -358,27 +363,27 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
   });
 }
 
-StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback){
+StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback) {
   var self = this;
   var prevPending = self.blockchain.pending_transactions.length;
-  if (prevPending===0){
+  if (prevPending === 0){
     return callback();
   }
-  self.blockchain.processNextBlock(function(err,results){
+  self.blockchain.processNextBlock(function(err, results){
     if (err) return callback(err);
 
     var result = results.results[0];
     if (result.vm.exception != 1) {
       return callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
-    }else if (self.blockchain.pending_transactions.length!==prevPending && self.blockchain.pending_transactions.length!==0){
-      //We added some transactions, and there are more to go
+    }else if (self.blockchain.pending_transactions.length !== prevPending && self.blockchain.pending_transactions.length !==0 ){
+      // We added some transactions, and there are more to go
       return self.processBlocksUntilNoMoreTransactionsAdded(callback);
     }else{
-      //No more pending transactions - I guess we're done here.
+      // No more pending transactions - I guess we're done here.
       callback();
     }
   })
-}
+};
 
 StateManager.prototype.processTransaction = function(from, tx, callback) {
   var self = this;
@@ -387,7 +392,7 @@ StateManager.prototype.processTransaction = function(from, tx, callback) {
 
   var tx_hash = to.hex(tx.hash());
 
-  if (self.no_mine_after_transaction){
+  if (self.is_mining == false){
     return callback(null, tx_hash);
   }
 
@@ -487,6 +492,16 @@ StateManager.prototype.hasContractCode = function(address, callback) {
       callback( null, true );
     }
   });
+}
+
+StateManager.prototype.startMining = function(callback) {
+  this.is_mining = true;
+  this.processBlocksUntilNoMoreTransactionsAdded(callback);
+};
+
+StateManager.prototype.stopMining = function(callback) {
+  this.is_mining = false;
+  callback();
 }
 
 module.exports = StateManager;

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -52,7 +52,7 @@ StateManager = function(options) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
 
-  this.no_mine_after_transaction = options.no_mine_after_transaction;
+  this.no_mine_after_transaction = false;
 }
 
 StateManager.prototype.initialize = function(options, callback) {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -240,7 +240,7 @@ StateManager.prototype.queueTransaction = function(method, tx_params, callback) 
 
   var rawTx = {
       gasPrice: "0x1",
-      gasLimit: this.blockchain.gasLimit,
+      gasLimit: this.blockchain.defaultTransactionGasLimit,
       value: '0x0',
       data: ''
   };
@@ -275,7 +275,7 @@ StateManager.prototype.queueTransaction = function(method, tx_params, callback) 
   }
 
   // If the transaction has a higher gas limit than the block gas limit, error.
-  if (to.number(rawTx.gasLimit) > to.number(this.blockchain.gasLimit)) {
+  if (to.number(rawTx.gasLimit) > to.number(this.blockchain.blockGasLimit)) {
     return callback(new Error("Exceeds block gas limit"));
   }
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -442,6 +442,7 @@ StateManager.prototype.getLogs = function(filter, callback) {
   var self = this;
 
   var expectedAddress = filter.address;
+  var expectedTopics = filter.topics || [];
   var fromBlock = this.blockchain.getEffectiveBlockNumber(filter.fromBlock || "latest");
   var toBlock = this.blockchain.getEffectiveBlockNumber(filter.toBlock || "latest");
 
@@ -454,8 +455,22 @@ StateManager.prototype.getLogs = function(filter, callback) {
     self.blockchain.getBlockLogs(current, function(err, blockLogs) {
       if (err) return finished(err);
 
+      // Filter logs that match the address
       var filtered = blockLogs.filter(function(log) {
-        return expectedAddress == null || log.address == expectedAddress;
+        return (expectedAddress == null || log.address == expectedAddress);
+      });
+
+      // Now filter based on topics.
+      filtered = filtered.filter(function(log) {
+        var keep = true;
+        for (var i = 0; i < expectedTopics.length; i++) {
+          if (expectedTopics[i] == null) continue;
+          if (i >= log.topics.length || expectedTopics[i] != log.topics[i]) {
+            keep = false;
+            break;
+          }
+        }
+        return keep;
       });
 
       logs.push.apply(logs, filtered);

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -361,6 +361,9 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
 StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback){
   var self = this;
   var prevPending = self.blockchain.pending_transactions.length;
+  if (prevPending===0){
+    return callback();
+  }
   self.blockchain.processNextBlock(function(err,results){
     if (err) return callback(err);
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -409,6 +409,10 @@ StateManager.prototype.getTransactionReceipt = function(hash, callback) {
   this.blockchain.getTransactionReceipt(hash, callback);
 };
 
+StateManager.prototype.getBlock = function(hash_or_number, callback) {
+  this.blockchain.getBlock(hash_or_number, callback);
+};
+
 StateManager.prototype.getLogs = function(filter, callback) {
   var self = this;
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -33,7 +33,7 @@ StateManager = function(options) {
   this.stateTrie = this.blockchain.stateTrie;
 
   this.accounts = {};
-  this.locked = !!options.locked;
+  this.secure = !!options.secure;
   this.total_accounts = options.total_accounts || 10;
   this.coinbase = null;
 
@@ -91,7 +91,7 @@ StateManager.prototype.initialize = function(options, callback) {
     return obj;
   }, {});
 
-  if (!this.locked) {
+  if (!this.secure) {
     accounts.forEach(function(data) {
       self.unlocked_accounts[data.address] = data;
     });

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -1,6 +1,7 @@
 var Account = require('ethereumjs-account');
 var Block = require('ethereumjs-block');
 var VM = require('ethereumjs-vm');
+var RuntimeError = require('./utils/runtimeerror');
 var Trie = require('merkle-patricia-tree');
 var FakeTransaction = require('ethereumjs-tx/fake.js');
 var utils = require('ethereumjs-util');
@@ -11,6 +12,7 @@ var async = require("async");
 var BlockchainDouble = require("./blockchain_double.js");
 var ForkedBlockchain = require("./utils/forkedblockchain.js");
 var Web3 = require('web3');
+var async = require("async");
 
 var to = require('./utils/to');
 var random = require('./utils/random');
@@ -365,10 +367,12 @@ StateManager.prototype.sign = function(address, dataToSign) {
   return utils.addHexPrefix(r.concat(s, v));
 };
 
-StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
+StateManager.prototype.printTransactionReceipt = function(tx_hash, error, callback){
   var self = this;
 
   self.blockchain.getTransactionReceipt(tx_hash, function(err, receipt) {
+    if (err) return callback(err);
+
     var block = self.blockchain.latestBlock();
     receipt = receipt.toJSON();
 
@@ -382,32 +386,58 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
     self.logger.log("  Gas usage: " + receipt.gasUsed);
     self.logger.log("  Block Number: " + receipt.blockNumber);
     self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
+
+    if (error) {
+      self.logger.log("  Runtime Error: " + error);
+    }
+
     self.logger.log("");
 
     callback(null, tx_hash);
   });
 }
 
-StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback) {
+StateManager.prototype.processAvailableTransactions = function(callback) {
   var self = this;
-  var prevPending = self.blockchain.pending_transactions.length;
-  if (prevPending === 0){
-    return callback();
-  }
-  self.blockchain.processNextBlock(function(err, results){
-    if (err) return callback(err);
 
-    var result = results.results[0];
-    if (result.vm.exception != 1) {
-      return callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
-    }else if (self.blockchain.pending_transactions.length !== prevPending && self.blockchain.pending_transactions.length !==0 ){
-      // We added some transactions, and there are more to go
-      return self.processBlocksUntilNoMoreTransactionsAdded(callback);
-    }else{
-      // No more pending transactions - I guess we're done here.
-      callback();
-    }
-  })
+  // Note: VM errors (errors that the VM directly returns) trump all runtime errors.
+  var runtime_error = null;
+
+  async.whilst(function() {
+    return self.blockchain.pending_transactions.length;
+  }, function(done) {
+    self.blockchain.processNextBlock(function(err, transactions, vm_output) {
+      if (err) {
+        if (err instanceof RuntimeError == false) {
+          // This is bad. Get out.
+          return done(err);
+        }
+
+        // We must have a RuntimeError. Merge results if we've found
+        // other runtime errors during this execution.
+        if (runtime_error == null) {
+          runtime_error = err;
+        } else {
+          runtime_error.combine(err);
+        }
+      }
+
+      // Note we don't quit on runtime errors. We keep processing transactions.
+      // Print the transaction receipts then move onto the next one.
+
+      // TODO: Can we refactor printTransactionReceipt so it's synchronous?
+      // We technically have the raw vm receipts (though they're not full receipts here...).
+      var receipts = vm_output.receipts;
+      async.eachSeries(transactions, function(tx, finished_printing) {
+        var hash = to.hex(tx.hash());
+        var error = runtime_error == null ? {results: {}} : runtime_error;
+        self.printTransactionReceipt(hash, error.results[hash], finished_printing);
+      }, done);
+    });
+  }, function(err) {
+    // Remember: vm errors trump runtime errors
+    callback(err || runtime_error);
+  });
 };
 
 StateManager.prototype.processTransaction = function(from, tx, callback) {
@@ -421,13 +451,13 @@ StateManager.prototype.processTransaction = function(from, tx, callback) {
     return callback(null, tx_hash);
   }
 
-  self.processBlocksUntilNoMoreTransactionsAdded(function(err, results){
-    if (err){
-      return callback(err)
-    }
-    self.printTransactionReceipt(tx_hash, callback);
-  })
-
+  // Note: When instamining, there will only be one transaction to process.
+  // We're using processAvailableTransactions for convenience (smell?).
+  // Because this is safe to assume, we return the transaction hash itself.
+  self.processAvailableTransactions(function(err) {
+    if (err) return callback(err);
+    callback(null, tx_hash);
+  });
 };
 
 StateManager.prototype.getTransactionReceipt = function(hash, callback) {
@@ -525,6 +555,9 @@ StateManager.prototype.revert = function(snapshot_id, callback) {
     }
   }
 
+  // Pending transactions are removed when you revert.
+  this.blockchain.clearPendingTransactions();
+
   return true;
 };
 
@@ -540,7 +573,7 @@ StateManager.prototype.hasContractCode = function(address, callback) {
 
 StateManager.prototype.startMining = function(callback) {
   this.is_mining = true;
-  this.processBlocksUntilNoMoreTransactionsAdded(callback);
+  this.processAvailableTransactions(callback);
 };
 
 StateManager.prototype.stopMining = function(callback) {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -33,6 +33,8 @@ StateManager = function(options) {
   this.stateTrie = this.blockchain.stateTrie;
 
   this.accounts = {};
+  this.locked = !!options.locked;
+  this.total_accounts = options.total_accounts || 10;
   this.coinbase = null;
 
   this.latest_filter_id = 1;
@@ -60,12 +62,10 @@ StateManager.prototype.initialize = function(options, callback) {
 
   var accounts = [];
 
-  var total_accounts = this.total_accounts || 10;
-
   if (options.accounts) {
     accounts = options.accounts.map(this.createAccount.bind(this));
   } else {
-    for (var i = 0; i < total_accounts; i++) {
+    for (var i = 0; i < this.total_accounts; i++) {
       accounts.push(self.createAccount({
         index: i
       }));
@@ -78,6 +78,24 @@ StateManager.prototype.initialize = function(options, callback) {
   accounts.forEach(function(data) {
     self.accounts[data.address] = data;
   });
+
+  // Turn array into object, mostly for speed purposes.
+  // No need for caller to specify private keys.
+  this.unlocked_accounts = (options.unlocked_accounts || []).reduce(function(obj, address) {
+    // If it doesn't have a hex prefix, must be a number (either a string or number type).
+    if ((address + "").indexOf("0x") != 0) {
+      address = accounts[parseInt(address)].address;
+    }
+
+    obj[address.toLowerCase()] = true; // can be any value
+    return obj;
+  }, {});
+
+  if (!this.locked) {
+    accounts.forEach(function(data) {
+      self.unlocked_accounts[data.address] = data;
+    });
+  }
 
   this.blockchain.initialize(accounts, function(err) {
     if (err) return callback(err);
@@ -213,9 +231,10 @@ StateManager.prototype.queueTransaction = function(method, tx_params, callback) 
     return;
   }
 
-  tx_params.from = utils.addHexPrefix(tx_params.from);
+  // use toLowerCase() to properly handle from addresses meant to be validated.
+  tx_params.from = utils.addHexPrefix(tx_params.from).toLowerCase();
 
-  if (method == "eth_sendTransaction" && Object.keys(this.accounts).indexOf(tx_params.from) < 0) {
+  if (method == "eth_sendTransaction" && this.unlocked_accounts[tx_params.from] == null) {
     return callback(new Error("could not unlock signer account"));
   }
 
@@ -329,7 +348,13 @@ StateManager.prototype.processNextAction = function(override) {
 };
 
 StateManager.prototype.sign = function(address, dataToSign) {
-  var secretKey = this.accounts[to.hex(address)].secretKey;
+  var account = this.accounts[to.hex(address)];
+
+  if (!account) {
+    throw new Error("cannot sign data; no private key");
+  }
+
+  var secretKey = account.secretKey;
   var sgn = utils.ecsign(new Buffer(dataToSign.replace('0x',''), 'hex'), new Buffer(secretKey));
   var r = utils.fromSigned(sgn.r);
   var s = utils.fromSigned(sgn.s);
@@ -506,6 +531,10 @@ StateManager.prototype.startMining = function(callback) {
 StateManager.prototype.stopMining = function(callback) {
   this.is_mining = false;
   callback();
-}
+};
+
+StateManager.prototype.isUnlocked = function(address) {
+  return this.unlocked_accounts[address.toLowerCase()] != null;
+};
 
 module.exports = StateManager;

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -335,46 +335,66 @@ StateManager.prototype.sign = function(address, dataToSign) {
   return utils.addHexPrefix(r.concat(s, v));
 };
 
-StateManager.prototype.processTransaction = function(from, tx, callback) {
+StateManager.prototype.printTransactionReceipt = function(tx_hash, callback){
   var self = this;
 
-  this.blockchain.queueTransaction(tx);
+  self.blockchain.getTransactionReceipt(tx_hash, function(err, receipt) {
+    var block = self.blockchain.latestBlock();
+    receipt = receipt.toJSON();
 
-  var tx_hash = to.hex(tx.hash());
-  if (this.no_mine_after_transaction){
-    return callback(null, tx_hash);
-  }
+    self.logger.log("");
+    self.logger.log("  Transaction: " + tx_hash);
 
-  this.blockchain.processNextBlock(function(err, results) {
+    if (receipt.contractAddress != null) {
+      self.logger.log("  Contract created: " + receipt.contractAddress);
+    }
+
+    self.logger.log("  Gas usage: " + receipt.gasUsed);
+    self.logger.log("  Block Number: " + receipt.blockNumber);
+    self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
+    self.logger.log("");
+
+    callback(null, tx_hash);
+  });
+}
+
+StateManager.prototype.processBlocksUntilNoMoreTransactionsAdded = function(callback){
+  var self = this;
+  var prevPending = self.blockchain.pending_transactions.length;
+  self.blockchain.processNextBlock(function(err,results){
     if (err) return callback(err);
 
     var result = results.results[0];
-
     if (result.vm.exception != 1) {
-      callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
-      return;
+      return callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
+    }else if (self.blockchain.pending_transactions.length!==prevPending && self.blockchain.pending_transactions.length!==0){
+      //We added some transactions, and there are more to go
+      return self.processBlocksUntilNoMoreTransactionsAdded(callback);
+    }else{
+      //No more pending transactions - I guess we're done here.
+      callback();
     }
+  })
+}
 
-    var block = self.blockchain.latestBlock();
+StateManager.prototype.processTransaction = function(from, tx, callback) {
+  var self = this;
 
-    self.blockchain.getTransactionReceipt(tx_hash, function(err, receipt) {
-      receipt = receipt.toJSON();
+  self.blockchain.queueTransaction(tx);
 
-      self.logger.log("");
-      self.logger.log("  Transaction: " + tx_hash);
+  var tx_hash = to.hex(tx.hash());
 
-      if (receipt.contractAddress != null) {
-        self.logger.log("  Contract created: " + receipt.contractAddress);
-      }
+  if (self.no_mine_after_transaction){
+    return callback(null, tx_hash);
+  }
 
-      self.logger.log("  Gas usage: " + receipt.gasUsed);
-      self.logger.log("  Block Number: " + receipt.blockNumber);
-      self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
-      self.logger.log("");
+  self.processBlocksUntilNoMoreTransactionsAdded(function(err, results){
+    if (err){
+      return callback(err)
+    }
+    self.printTransactionReceipt(tx_hash, callback);
+  })
 
-      callback(null, tx_hash);
-    });
-  });
 };
 
 StateManager.prototype.getTransactionReceipt = function(hash, callback) {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -57,6 +57,9 @@ StateManager = function(options) {
   }
 
   this.is_mining = true;
+  this.blocktime = options.blocktime;
+  this.is_mining_on_interval = !!options.blocktime;
+  this.mining_interval_timeout = null;
 }
 
 StateManager.prototype.initialize = function(options, callback) {
@@ -108,9 +111,8 @@ StateManager.prototype.initialize = function(options, callback) {
       self.net_version = self.blockchain.fork_version || new Date().getTime();
     }
 
-    if (options.blocktime) {
-      self.blocktime = options.blocktime;
-      setTimeout(self.mineOnInterval.bind(self), self.blocktime * 1000);
+    if (self.is_mining_on_interval) {
+      self.mineOnInterval();
     }
 
     callback();
@@ -120,14 +122,22 @@ StateManager.prototype.initialize = function(options, callback) {
 StateManager.prototype.mineOnInterval = function() {
   var self = this;
 
-  // Queue up to mine the block once the transaction is finished.
-  if (this.transaction_processing == true) {
-    setTimeout(this.mineOnInterval.bind(this), 100);
-  } else {
-    this.blockchain.processNextBlock(function(err) {
-      // TODO: What do we do with the errors?
-      setTimeout(self.mineOnInterval.bind(self), self.blocktime * 1000);
+  // For good measure.
+  clearTimeout(this.mining_interval_timeout);
+  this.mining_interval_timeout = null;
+
+  this.mining_interval_timeout = setTimeout(function() {
+    // Only process one block.
+    self.processBlocks(1, function(err) {
+      // Note: Errors are ignored as they're printed to the log
+      // After processing this block, queue up processing the next block.
+      self.mineOnInterval();
     });
+  }, this.blocktime * 1000);
+
+  // Ensure this won't keep a node process open.
+  if (this.mining_interval_timeout.unref) {
+    this.mining_interval_timeout.unref();
   }
 };
 
@@ -397,16 +407,32 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, error, callba
   });
 }
 
-StateManager.prototype.processAvailableTransactions = function(callback) {
+StateManager.prototype.processBlocks = function(total_blocks, callback) {
   var self = this;
+
+  if (typeof total_blocks == "function") {
+    callback = total_blocks;
+    total_blocks = null;
+  }
 
   // Note: VM errors (errors that the VM directly returns) trump all runtime errors.
   var runtime_error = null;
+  var amount_processed = 0;
 
   async.whilst(function() {
-    return self.blockchain.pending_transactions.length;
+    var shouldContinue;
+
+    if (total_blocks == null) {
+      shouldContinue = self.blockchain.pending_transactions.length > 0;
+    } else {
+      shouldContinue = amount_processed < total_blocks;
+    }
+
+    return shouldContinue;
   }, function(done) {
     self.blockchain.processNextBlock(function(err, transactions, vm_output) {
+      amount_processed += 1;
+
       if (err) {
         if (err instanceof RuntimeError == false) {
           // This is bad. Get out.
@@ -447,14 +473,13 @@ StateManager.prototype.processTransaction = function(from, tx, callback) {
 
   var tx_hash = to.hex(tx.hash());
 
-  if (self.is_mining == false){
+  // If we're not currently mining or we're mining on an interval,
+  // only queue the transaction, don't process it.
+  if (self.is_mining == false || self.is_mining_on_interval){
     return callback(null, tx_hash);
   }
 
-  // Note: When instamining, there will only be one transaction to process.
-  // We're using processAvailableTransactions for convenience (smell?).
-  // Because this is safe to assume, we return the transaction hash itself.
-  self.processAvailableTransactions(function(err) {
+  self.processBlocks(function(err) {
     if (err) return callback(err);
     callback(null, tx_hash);
   });
@@ -573,11 +598,19 @@ StateManager.prototype.hasContractCode = function(address, callback) {
 
 StateManager.prototype.startMining = function(callback) {
   this.is_mining = true;
-  this.processAvailableTransactions(callback);
+
+  if (this.is_mining_on_interval) {
+    this.mineOnInterval();
+    callback();
+  } else {
+    this.processBlocks(callback);
+  }
 };
 
 StateManager.prototype.stopMining = function(callback) {
   this.is_mining = false;
+  clearTimeout(this.mining_interval_timeout);
+  this.mining_interval_timeout = null;
   callback();
 };
 

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -245,16 +245,16 @@ GethApiDouble.prototype.net_version = function(callback) {
 };
 
 GethApiDouble.prototype.miner_start = function(threads, callback) {
-  this.state.no_mine_after_transaction = false;
-  this.state.processBlocksUntilNoMoreTransactionsAdded(function(err) {
+  this.state.startMining(function(err) {
     callback(err, true);
   });
-}
+};
 
 GethApiDouble.prototype.miner_stop = function(callback) {
-  this.state.no_mine_after_transaction = true;
-  callback(null, true);
-}
+  this.state.stopMining(function(err) {
+    callback(err, true);
+  });
+};
 
 /* Functions for testing purposes only. */
 

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -251,7 +251,7 @@ GethApiDouble.prototype.miner_start = function(threads, callback) {
   });
 }
 
-GethApiDouble.prototype.miner_stop = function(threads, callback) {
+GethApiDouble.prototype.miner_stop = function(callback) {
   this.state.no_mine_after_transaction = true;
   callback(null, true);
 }

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -174,6 +174,31 @@ GethApiDouble.prototype.eth_getTransactionByHash = function(hash, callback) {
   });
 }
 
+GethApiDouble.prototype.eth_getTransactionByBlockHashAndIndex = function(hash_or_number, index, callback) {
+  var self = this;
+
+  index = to.number(index);
+
+  this.state.getBlock(hash_or_number, function(err, block) {
+    if (err) return callback(err);
+
+    if (index >= block.transactions.length) {
+      return callback(new Error("Transaction at index " + to.hex(index) + " does not exist in block."));
+    }
+
+    var tx = block.transactions[index];
+    var result = txhelper.toJSON(tx, block);
+
+    callback(null, result);
+  });
+};
+
+GethApiDouble.prototype.eth_getTransactionByBlockNumberAndIndex = function(hash_or_number, index, callback) {
+  this.eth_getTransactionByBlockHashAndIndex(hash_or_number, index, callback);
+};
+
+
+
 GethApiDouble.prototype.eth_getTransactionCount = function(address, block_number, callback) {
   this.state.getTransactionCount(address, block_number, callback);
 }

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -96,7 +96,7 @@ GethApiDouble.prototype.eth_coinbase = function(callback) {
 };
 
 GethApiDouble.prototype.eth_mining = function(callback) {
-  callback(null, true);
+  callback(null, this.state.is_mining);
 };
 
 GethApiDouble.prototype.eth_hashrate = function(callback) {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -244,6 +244,19 @@ GethApiDouble.prototype.net_version = function(callback) {
   callback(null, this.state.net_version + "");
 };
 
+GethApiDouble.prototype.miner_start = function(threads, callback) {
+  this.state.no_mine_after_transaction = false;
+  //Mine [TODO: if we have pending transactions?]
+  this.state.blockchain.processNextBlock(function(err) {
+    callback(err, true);
+  });
+}
+
+GethApiDouble.prototype.miner_stop = function(threads, callback) {
+  this.state.no_mine_after_transaction = true;
+  callback(null, true);
+}
+
 /* Functions for testing purposes only. */
 
 GethApiDouble.prototype.evm_snapshot = function(callback) {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -204,7 +204,16 @@ GethApiDouble.prototype.eth_getTransactionCount = function(address, block_number
 }
 
 GethApiDouble.prototype.eth_sign = function(address, dataToSign, callback) {
-    callback(null, this.state.sign(address, dataToSign));
+  var result;
+  var error;
+
+  try {
+    result = this.state.sign(address, dataToSign);
+  } catch (e) {
+    error = e;
+  }
+
+  callback(error, result);
 };
 
 GethApiDouble.prototype.eth_sendTransaction = function(tx_data, callback) {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -246,8 +246,7 @@ GethApiDouble.prototype.net_version = function(callback) {
 
 GethApiDouble.prototype.miner_start = function(threads, callback) {
   this.state.no_mine_after_transaction = false;
-  //Mine [TODO: if we have pending transactions?]
-  this.state.blockchain.processNextBlock(function(err) {
+  this.state.processBlocksUntilNoMoreTransactionsAdded(function(err) {
     callback(err, true);
   });
 }

--- a/lib/utils/runtimeerror.js
+++ b/lib/utils/runtimeerror.js
@@ -1,0 +1,70 @@
+var inherits = require("util").inherits;
+var to = require("./to");
+
+inherits(RuntimeError, Error);
+
+// Note: ethereumjs-vm will return an object that has a "results" and "receipts" keys.
+// You should pass in the whole object.
+function RuntimeError(transactions, vm_output) {
+  Error.call(this);
+  this.results = {};
+  this.combine(transactions, vm_output);
+};
+
+RuntimeError.prototype.combine = function(transactions, vm_output) {
+  // Can be combined with vm_output or another RuntimeError.
+  if (transactions instanceof RuntimeError) {
+    var err = transactions;
+    var keys = Object.keys(err.results);
+
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      this.results[key] = err.results[key];
+    }
+  } else {
+    var results = vm_output.results;
+    var receipts = vm_output.receipts;
+
+    for (var i = 0; i < transactions.length; i++) {
+      var tx = transactions[i];
+      var result = results[i];
+      var receipt = receipts[i];
+
+      // 1 means no error, oddly.
+      if (result.vm.exception != 1) {
+        this.results[to.hex(tx.hash())] = result.vm.exceptionError;
+      }
+    }
+  }
+
+  var hashes = Object.keys(this.results);
+
+  // Once combined, set the message
+  if (hashes.length == 1) {
+    this.message = "VM Exception while processing transaction: " + this.results[hashes[0]];
+  } else {
+    this.message = "Multiple VM Exceptions while processing transactions: \n\n";
+
+    for (var i = 0; i < hashes.length; i++) {
+      var hash = hashes[i];
+
+      this.message += hash + ": " + this.results[hash] + "\n";
+    }
+  }
+};
+
+RuntimeError.prototype.count = function() {
+  return Object.keys(this.results).length;
+};
+
+RuntimeError.fromResults = function(transactions, vm_output) {
+  var err = new RuntimeError(transactions, vm_output);
+
+  if (err.count() == 0) {
+    return null;
+  }
+
+  return err;
+};
+
+module.exports = RuntimeError;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "merkle-patricia-tree": "^2.1.2",
     "seedrandom": "^2.4.2",
     "shelljs": "^0.6.0",
+    "solc": "^0.4.2",
     "web3": "^0.16.0",
     "web3-provider-engine": "^8.0.3",
     "yargs": "^3.29.0"
@@ -35,8 +36,7 @@
     "eslint": "^3.0.1",
     "eslint-config-standard": "^5.3.5",
     "eslint-plugin-standard": "^1.3.3",
-    "mocha": "^2.2.5",
-    "solc": "^0.3.0-1"
+    "mocha": "^2.2.5"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "shelljs": "^0.6.0",
     "solc": "^0.4.2",
     "web3": "^0.16.0",
-    "web3-provider-engine": "^8.0.3",
+    "web3-provider-engine": "^8.1.0",
     "yargs": "^3.29.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ethereumjs-vm": "^1.3.0",
     "ethereumjs-wallet": "^0.6.0",
     "fake-merkle-patricia-tree": "^1.0.1",
+    "heap": "^0.2.6",
     "merkle-patricia-tree": "^2.1.2",
     "seedrandom": "^2.4.2",
     "shelljs": "^0.6.0",

--- a/test/EstimateGas.sol
+++ b/test/EstimateGas.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.2;
+
 // From https://github.com/ethereumjs/testrpc/issues/58
 contract EstimateGas {
     event Add(bytes32 name, bytes32 description, uint value, address owner);

--- a/test/Example.sol
+++ b/test/Example.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.2;
+
 contract Example {
   uint public value;
 

--- a/test/Oracle.sol
+++ b/test/Oracle.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.2;
+
 contract Oracle{
   bytes32 public blockhash0;
   uint public lastBlock;

--- a/test/accounts.js
+++ b/test/accounts.js
@@ -3,12 +3,13 @@ var TestRPC = require("../index.js");
 var assert = require('assert');
 
 describe("Accounts", function() {
-  it("should respect the BIP99 mnemonic", function(done) {
-    var expected_address = "0x604a95C9165Bc95aE016a5299dd7d400dDDBEa9A";
+  var expected_address = "0x604a95C9165Bc95aE016a5299dd7d400dDDBEa9A";
+  var mnemonic = "into trim cross then helmet popular suit hammer cart shrug oval student";
 
+  it("should respect the BIP99 mnemonic", function(done) {
     var web3 = new Web3();
     web3.setProvider(TestRPC.provider({
-      mnemonic: "into trim cross then helmet popular suit hammer cart shrug oval student"
+      mnemonic: mnemonic
     }));
 
     web3.eth.getAccounts(function(err, accounts) {
@@ -17,5 +18,127 @@ describe("Accounts", function() {
       assert(accounts[0].toLowerCase(), expected_address.toLowerCase());
       done();
     });
-  })
+  });
+
+  it("should lock all accounts when specified", function(done) {
+    var web3 = new Web3();
+    web3.setProvider(TestRPC.provider({
+      mnemonic: mnemonic,
+      locked: true
+    }));
+
+    web3.eth.sendTransaction({
+      from: expected_address,
+      to: "0x1234567890123456789012345678901234567890", // doesn't need to exist
+      value: web3.toWei(1, "Ether"),
+      gasLimit: 90000
+    }, function(err, tx) {
+      if (!err) return done(new Error("We expected the account to be locked, which should throw an error when sending a transaction"));
+      assert(err.message.toLowerCase().indexOf("could not unlock signer account") >= 0);
+      done();
+    });
+  });
+
+  it("should unlock specified accounts, in conjunction with --secure", function(done) {
+    var web3 = new Web3();
+    web3.setProvider(TestRPC.provider({
+      mnemonic: mnemonic,
+      locked: true,
+      unlocked_accounts: [expected_address]
+    }));
+
+    web3.eth.sendTransaction({
+      from: expected_address,
+      to: "0x1234567890123456789012345678901234567890", // doesn't need to exist
+      value: web3.toWei(1, "Ether"),
+      gasLimit: 90000
+    }, function(err, tx) {
+      if (err) return done(err);
+      // We should have no error here because the account is unlocked.
+      done();
+    });
+  });
+
+  it("should unlock specified accounts, in conjunction with --secure, using array indexes", function(done) {
+    var web3 = new Web3();
+    web3.setProvider(TestRPC.provider({
+      mnemonic: mnemonic,
+      locked: true,
+      unlocked_accounts: [0]
+    }));
+
+    web3.eth.sendTransaction({
+      from: expected_address,
+      to: "0x1234567890123456789012345678901234567890", // doesn't need to exist
+      value: web3.toWei(1, "Ether"),
+      gasLimit: 90000
+    }, function(err, tx) {
+      if (err) return done(err);
+      // We should have no error here because the account is unlocked.
+      done();
+    });
+  });
+
+  it("should unlock accounts even if private key isn't managed by the testrpc (impersonation)", function(done) {
+    var second_address = "0x1234567890123456789012345678901234567890";
+
+    var web3 = new Web3();
+    web3.setProvider(TestRPC.provider({
+      mnemonic: mnemonic,
+      locked: true,
+      unlocked_accounts: [0, second_address]
+    }));
+
+    // Set up: give second address some ether
+    web3.eth.sendTransaction({
+      from: expected_address,
+      to: second_address,
+      value: web3.toWei(10, "Ether"),
+      gasLimit: 90000
+    }, function(err, tx) {
+      if (err) return done(err);
+
+      // Now we should be able to send a transaction from second address without issue.
+      web3.eth.sendTransaction({
+        from: second_address,
+        to: expected_address,
+        value: web3.toWei(5, "Ether"),
+        gasLimit: 90000
+      }, function(err, tx) {
+        if (err) return done(err);
+
+        // And for the heck of it let's check the balance just to make sure it went througj
+        web3.eth.getBalance(second_address, function(err, balance) {
+          if (err) return done(err);
+
+          var balanceInEther = web3.fromWei(balance, "Ether");
+
+          // Can't check the balance exactly. It cost some ether to send the transaction.
+          assert(balanceInEther.gt(4));
+          assert(balanceInEther.lt(5));
+          done();
+        });
+      });
+    });
+  });
+
+  it("errors when we try to sign a transaction from an account we're impersonating", function(done) {
+    var second_address = "0x1234567890123456789012345678901234567890";
+
+    var web3 = new Web3();
+    web3.setProvider(TestRPC.provider({
+      mnemonic: mnemonic,
+      locked: true,
+      unlocked_accounts: [0, second_address]
+    }));
+
+    web3.eth.sign(second_address, "some data", function(err, result) {
+      if (!err) return done(new Error("Expected an error while signing when not managing the private key"));
+
+      assert(err.message.toLowerCase().indexOf("cannot sign data; no private key") >= 0);
+      done();
+    });
+  });
+
+
 });

--- a/test/accounts.js
+++ b/test/accounts.js
@@ -24,7 +24,7 @@ describe("Accounts", function() {
     var web3 = new Web3();
     web3.setProvider(TestRPC.provider({
       mnemonic: mnemonic,
-      locked: true
+      secure: true
     }));
 
     web3.eth.sendTransaction({
@@ -43,7 +43,7 @@ describe("Accounts", function() {
     var web3 = new Web3();
     web3.setProvider(TestRPC.provider({
       mnemonic: mnemonic,
-      locked: true,
+      secure: true,
       unlocked_accounts: [expected_address]
     }));
 
@@ -63,7 +63,7 @@ describe("Accounts", function() {
     var web3 = new Web3();
     web3.setProvider(TestRPC.provider({
       mnemonic: mnemonic,
-      locked: true,
+      secure: true,
       unlocked_accounts: [0]
     }));
 
@@ -85,7 +85,7 @@ describe("Accounts", function() {
     var web3 = new Web3();
     web3.setProvider(TestRPC.provider({
       mnemonic: mnemonic,
-      locked: true,
+      secure: true,
       unlocked_accounts: [0, second_address]
     }));
 
@@ -128,7 +128,7 @@ describe("Accounts", function() {
     var web3 = new Web3();
     web3.setProvider(TestRPC.provider({
       mnemonic: mnemonic,
-      locked: true,
+      secure: true,
       unlocked_accounts: [0, second_address]
     }));
 

--- a/test/block_tags.js
+++ b/test/block_tags.js
@@ -80,9 +80,10 @@ describe("Block Tags", function() {
   before("Make transaction that changes balance, nonce and code", function(done) {
     web3.eth.sendTransaction({
       from: accounts[0],
-      data: contract.binary
+      data: contract.binary,
+      gas: 3141592
     }, function(err, tx) {
-      if (err) return callback(err);
+      if (err) return done(err);
 
       web3.eth.getTransactionReceipt(tx, function(err, receipt) {
         if (err) return done(err);

--- a/test/events.js
+++ b/test/events.js
@@ -5,6 +5,7 @@ var solc = require("solc");
 var async = require("async");
 
 var source = "                      \
+pragma solidity ^0.4.2;             \
 contract EventTest {                \
   event ExampleEvent(uint indexed first, uint indexed second);   \
                                     \

--- a/test/forking.js
+++ b/test/forking.js
@@ -85,7 +85,8 @@ describe("Forking", function() {
   before("Deploy initial contracts", function(done) {
     forkedWeb3.eth.sendTransaction({
       from: forkedAccounts[0],
-      data: contract.binary
+      data: contract.binary,
+      gas: 3141592
     }, function(err, tx) {
       if (err) { return done(err); }
 
@@ -100,7 +101,8 @@ describe("Forking", function() {
         // Deploy a second one, which we won't use often.
         forkedWeb3.eth.sendTransaction({
           from: forkedAccounts[0],
-          data: contract.binary
+          data: contract.binary,
+          gas: 3141592
         }, function(err, tx) {
           if (err) { return done(err); }
           forkedWeb3.eth.getTransactionReceipt(tx, function(err, receipt) {
@@ -361,7 +363,7 @@ describe("Forking", function() {
     var oracleSol = fs.readFileSync("./test/Oracle.sol", {encoding: "utf8"});
     var oracleOutput = solc.compile(oracleSol).contracts.Oracle;
 
-    mainWeb3.eth.contract(JSON.parse(oracleOutput.interface)).new({ data: oracleOutput.bytecode, from: mainAccounts[0] }, function(err, oracle){
+    mainWeb3.eth.contract(JSON.parse(oracleOutput.interface)).new({ data: oracleOutput.bytecode, from: mainAccounts[0], gas: 3141592 }, function(err, oracle){
       if(err) return done(err)
       if(!oracle.address) return
       mainWeb3.eth.getBlock(0, function(err, block){
@@ -378,7 +380,7 @@ describe("Forking", function() {
               if (err) return done(err);
               assert.equal(number, expected_number);
 
-              oracle.setCurrentBlock({from: mainAccounts[0]}, function(err, tx) {
+              oracle.setCurrentBlock({from: mainAccounts[0], gas: 3141592}, function(err, tx) {
                 if (err) return done(err);
 
                 oracle.lastBlock.call({from: mainAccounts[0]}, function(err, val) {

--- a/test/gas.js
+++ b/test/gas.js
@@ -29,7 +29,7 @@ describe("Gas Estimation", function() {
 
       EstimateGasContract = web3.eth.contract(abi);
       EstimateGasContract._code = code;
-      EstimateGasContract.new({data: code, from: accounts[0]}, function(err, instance) {
+      EstimateGasContract.new({data: code, from: accounts[0], gas: 3141592}, function(err, instance) {
         if (err) return done(err);
         if (!instance.address) return;
 
@@ -70,11 +70,11 @@ describe("Gas Estimation", function() {
   // });
 
   it("matches usage for complex function call (add)", function(done) {
-    testTransactionEstimate(EstimateGas.add, ["Tim", "A great guy", 5, {from: accounts[0]}], done);
+    testTransactionEstimate(EstimateGas.add, ["Tim", "A great guy", 5, {from: accounts[0], gas: 3141592}], done);
   });
 
   it("matches usage for complex function call (transfer)", function(done) {
-    testTransactionEstimate(EstimateGas.transfer, ["0x0123456789012345678901234567890123456789", 5, "Tim", {from: accounts[0]}], done);
+    testTransactionEstimate(EstimateGas.transfer, ["0x0123456789012345678901234567890123456789", 5, "Tim", {from: accounts[0], gas: 3141592}], done);
   });
 
 })

--- a/test/gas.js
+++ b/test/gas.js
@@ -20,7 +20,7 @@ describe("Gas Estimation", function() {
   });
 
   before("compile source", function(done) {
-    this.timeout(5000);
+    this.timeout(10000);
     web3.eth.compile.solidity(source, function(err, result) {
       if (err) return done(err);
 

--- a/test/interval_mining.js
+++ b/test/interval_mining.js
@@ -151,7 +151,7 @@ describe("Interval Mining", function() {
       logger: logger
     }));
 
-    web3.eth.compile.solidity("contract Example { function Example() {throw;} }", function(err, result) {
+    web3.eth.compile.solidity("pragma solidity ^0.4.2; contract Example { function Example() {throw;} }", function(err, result) {
       if (err) return done(err);
       var bytecode = "0x" + result.code;
 

--- a/test/interval_mining.js
+++ b/test/interval_mining.js
@@ -1,0 +1,175 @@
+var Web3 = require('web3');
+var TestRPC = require("../index.js");
+var assert = require('assert');
+var to = require("../lib/utils/to.js");
+
+describe("Interval Mining", function() {
+  var web3;
+
+  var mnemonic = "into trim cross then helmet popular suit hammer cart shrug oval student";
+  var first_address = "0x604a95C9165Bc95aE016a5299dd7d400dDDBEa9A";
+
+  it("should mine a block on the interval", function(done) {
+    this.timeout(5000);
+
+    web3 = new Web3(TestRPC.provider({
+      blocktime: 0.5, // seconds
+      mnemonic: mnemonic
+    }));
+
+    // Get the first block (pre-condition)
+    web3.eth.getBlockNumber(function(err, number) {
+      if (err) return done(err);
+      assert.equal(number, 0);
+
+      // Wait 1.25 seconds (two and a half mining intervals) then get the next block.
+      // It should be block number 2 (the third block). We wait more than one iteration
+      // to ensure the timeout gets reset.
+
+      setTimeout(function() {
+        // Get the first block (pre-condition)
+        web3.eth.getBlockNumber(function(err, latest_number) {
+          assert.equal(latest_number, 2);
+          done();
+        });
+      }, 1250);
+    });
+  });
+
+  it("shouldn't instamine when mining on an interval", function(done) {
+    this.timeout(5000);
+
+    web3 = new Web3(TestRPC.provider({
+      blocktime: 0.5, // seconds
+      mnemonic: mnemonic
+    }));
+
+    // Get the first block (pre-condition)
+    web3.eth.getBlockNumber(function(err, number) {
+      if (err) return done(err);
+      assert.equal(number, 0);
+
+      // Queue a transaction
+      web3.eth.sendTransaction({
+        from: first_address,
+        to: "0x1234567890123456789012345678901234567890",
+        value: web3.toWei(1, "Ether"),
+        gas: 90000
+      }, function(err, tx) {
+        if (err) return done(err);
+
+        // Ensure there's no receipt since the transaction hasn't yet been processed.
+        web3.eth.getTransactionReceipt(tx, function(err, receipt) {
+          if (err) return done(err);
+
+          assert.equal(receipt, null);
+
+          // Wait .75 seconds (one and a half mining intervals) then get the receipt. It should be processed.
+
+          setTimeout(function() {
+            // Get the first block (pre-condition)
+            web3.eth.getTransactionReceipt(tx, function(err, new_receipt) {
+              assert.notEqual(new_receipt, null);
+              done();
+            });
+          }, 750);
+        });
+
+      });
+    });
+  });
+
+  it("miner_stop should stop interval mining, and miner_start should start it again", function(done) {
+    this.timeout(5000);
+
+    web3 = new Web3(TestRPC.provider({
+      blocktime: 0.5, // seconds
+      mnemonic: mnemonic
+    }));
+
+    // Get the first block (pre-condition)
+    web3.eth.getBlockNumber(function(err, number) {
+      if (err) return done(err);
+      assert.equal(number, 0);
+
+      // Stop mining
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+        id: new Date().getTime()
+      }, function(err) {
+        if (err) return done(err);
+
+        // Wait .75 seconds (one and a half mining intervals) and ensure
+        // the block number hasn't increased.
+        setTimeout(function() {
+          web3.eth.getBlockNumber(function(err, latest_number) {
+            if (err) return done(err);
+            assert.equal(latest_number, 0);
+
+            // Start mining again
+            web3.currentProvider.sendAsync({
+              jsonrpc: "2.0",
+              method: "miner_start",
+              params: [1],
+              id: new Date().getTime()
+            }, function(err) {
+              if (err) return done(err);
+
+              // Wait .75 seconds (one and a half mining intervals) and ensure
+              // the block number has increased by one.
+              setTimeout(function() {
+                web3.eth.getBlockNumber(function(err, last_number) {
+                  if (err) return done(err);
+
+                  assert(last_number, latest_number + 1);
+                  done();
+                });
+              }, 750)
+
+            });
+          });
+        }, 750)
+
+      });
+    });
+  });
+
+  it("should log runtime errors to the log", function(done) {
+    this.timeout(5000);
+
+    var logData = "";
+    var logger = {
+      log: function(message) {
+        logData += message + "\n";
+      }
+    };
+
+    web3 = new Web3(TestRPC.provider({
+      blocktime: 0.5, // seconds
+      mnemonic: mnemonic,
+      logger: logger
+    }));
+
+    web3.eth.compile.solidity("contract Example { function Example() {throw;} }", function(err, result) {
+      if (err) return done(err);
+      var bytecode = "0x" + result.code;
+
+      web3.eth.sendTransaction({
+        from: first_address,
+        data: bytecode,
+        gas: 3141592
+      }, function(err, tx) {
+        if (err) return done(err);
+
+        // Wait .75 seconds (one and a half mining intervals) and ensure log sees error.
+        setTimeout(function() {
+          assert(logData.indexOf("Runtime Error: invalid JUMP") >= 0);
+          done();
+        }, 750);
+      });
+    });
+
+  });
+
+});

--- a/test/mining.js
+++ b/test/mining.js
@@ -6,9 +6,45 @@ var to = require("../lib/utils/to.js");
 describe("Block Processing", function() {
   var web3 = new Web3(TestRPC.provider());
   var accounts;
+  var snapshot_id;
+  var badBytecode;
+  var goodBytecode;
+
+  before("compile solidity code that causes runtime errors", function() {
+    return compileSolidity("contract Example { function Example() {throw;} }").then(function(result) {
+      badBytecode = "0x" + result.code;
+    });
+  });
+
+  before("compile solidity code that causes an event", function() {
+    return compileSolidity("contract Example { event Event(); function Example() { Event(); } }").then(function(result) {
+      goodBytecode = "0x" + result.code;
+    });
+  });
+
+  beforeEach("checkpoint, so that we can revert later", function(done) {
+    web3.currentProvider.sendAsync({
+      jsonrpc: "2.0",
+      method: "evm_snapshot",
+      id: new Date().getTime()
+    }, function(err, res) {
+      if (!err) {
+        snapshot_id = res.result;
+      }
+      done(err);
+    });
+  });
+
+  afterEach("revert back to checkpoint", function(done) {
+    web3.currentProvider.sendAsync({
+      jsonrpc: "2.0",
+      method: "evm_revert",
+      params: [snapshot_id],
+      id: new Date().getTime()
+    }, done);
+  });
 
   // Everything's a Promise to add in readibility.
-
   function getBlockNumber() {
     return new Promise(function(accept, reject) {
       web3.eth.getBlockNumber(function(err, number) {
@@ -45,13 +81,27 @@ describe("Block Processing", function() {
     });
   }
 
-  function queueTransaction(from, to, gasLimit, value) {
+  function mineSingleBlock() {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        id: new Date().getTime()
+      }, function(err) {
+        if (err) return reject(err);
+        accept();
+      })
+    });
+  }
+
+  function queueTransaction(from, to, gasLimit, value, data) {
     return new Promise(function(accept, reject) {
       web3.eth.sendTransaction({
         from: from,
         to: to,
         gas: gasLimit,
-        value: value
+        value: value,
+        data: data
       }, function(err, tx) {
         if (err) return reject(err);
         accept(tx);
@@ -62,6 +112,24 @@ describe("Block Processing", function() {
   function getReceipt(tx) {
     return new Promise(function(accept, reject) {
       web3.eth.getTransactionReceipt(tx, function(err, result) {
+        if (err) return reject(err);
+        accept(result);
+      });
+    });
+  };
+
+  function getCode(address) {
+    return new Promise(function(accept, reject) {
+      web3.eth.getCode(address, function(err, result) {
+        if (err) return reject(err);
+        accept(result);
+      });
+    });
+  };
+
+  function compileSolidity(source) {
+    return new Promise(function(accept, reject) {
+      web3.eth.compile.solidity(source, function(err, result) {
         if (err) return reject(err);
         accept(result);
       });
@@ -154,6 +222,45 @@ describe("Block Processing", function() {
     });
   });
 
+  it("should mine one block when requested, and only one transaction, when two queued transactions together are larger than a single block", function() {
+    // This is a very similar test to the above, except we don't start mining again,
+    // we only mine one block by request.
+
+    var tx1, tx2, blockNumber;
+
+    return stopMining().then(function() {
+      return getBlockNumber();
+    }).then(function(number) {
+      blockNumber = number;
+      return queueTransaction(accounts[0], accounts[1], 4000000, web3.toWei(2, "Ether"));
+    }).then(function(tx) {
+      tx1 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return queueTransaction(accounts[0], accounts[1], 4000000, web3.toWei(3, "Ether"));
+    }).then(function(tx) {
+      tx2 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return mineSingleBlock();
+    }).then(function() {
+      return Promise.all([getReceipt(tx1), getReceipt(tx2)]);
+    }).then(function(receipts) {
+      assert.equal(receipts.length, 2);
+      assert.notEqual(receipts[0], null);
+      assert.equal(receipts[0].transactionHash, tx1);
+      assert.equal(receipts[1], null);
+
+      return getBlockNumber();
+    }).then(function(number) {
+      assert.equal(number, blockNumber + 1);
+    });
+  });
+
   it("should error if queued transaction exceeds the block gas limit", function(done) {
     return stopMining().then(function() {
       return queueTransaction(accounts[0], accounts[1], 5000000, web3.toWei(2, "Ether"));
@@ -167,6 +274,126 @@ describe("Block Processing", function() {
       }
 
       done();
+    });
+  });
+
+  it("should error via instamining when queued transaction throws a runtime errors", function(done) {
+    var tx1, tx2, blockNumber, bytecode, address;
+
+    startMining().then(function() {
+      // This transaction should be processed immediately.
+      return queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
+    }).then(function(tx) {
+      throw new Error("Execution should never get here as we expected `eth_sendTransaction` to throw an error")
+    }).catch(function(err) {
+      if (err.message.indexOf("VM Exception while processing transaction") != 0) {
+        return done(new Error("Received error we didn't expect: " + err));
+      }
+      // We got the error we wanted. Test passed!
+      done();
+    });
+  });
+
+  it("should error via evm_mine when queued transaction throws a runtime errors", function(done) {
+    var tx1, tx2, blockNumber, bytecode, address;
+
+    stopMining().then(function() {
+      return queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
+    }).then(function(tx) {
+      tx1 = tx;
+      return mineSingleBlock();
+    }).then(function() {
+      throw new Error("Execution should never get here as we expected `evm_mine` to throw an error")
+    }).catch(function(err) {
+      if (err.message.indexOf("VM Exception while processing transaction") != 0) {
+        return done(new Error("Received error we didn't expect: " + err));
+      }
+      // We got the error we wanted. Test passed!
+      done();
+    });
+  });
+
+  it("should error via evm_mine when multiple queued transactions throw runtime errors in a single block", function(done) {
+    var tx1, tx2, blockNumber, bytecode;
+
+    // Note: The two transactions queued in this test do not exceed the block gas limit
+    // and thus should fit within a single block.
+
+    stopMining().then(function() {
+      return queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
+    }).then(function(tx) {
+      return queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
+    }).then(function(tx) {
+      return mineSingleBlock();
+    }).then(function() {
+      throw new Error("Execution should never get here as we expected `evm_mine` to throw an error")
+    }).catch(function(err) {
+      if (err.message.indexOf("Multiple VM Exceptions while processing transactions") != 0) {
+        return done(new Error("Received error we didn't expect: " + err));
+      }
+      // We got the error we wanted. Test passed!
+      done();
+    });
+  });
+
+  it("should error via miner_start when multiple queued transactions throw runtime errors in multiple blocks", function(done) {
+    var blockNumber, bytecode;
+
+    // Note: The two transactions queued in this test together DO exceed the block gas limit
+    // and thus will fit in two blocks, one block each.
+
+    stopMining().then(function() {
+      return queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
+    }).then(function(tx) {
+      return queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
+    }).then(function(tx) {
+      return startMining();
+    }).then(function() {
+      throw new Error("Execution should never get here as we expected `miner_start` to throw an error")
+    }).catch(function(err) {
+      if (err.message.indexOf("Multiple VM Exceptions while processing transactions") != 0) {
+        return done(new Error("Received error we didn't expect: " + err));
+      }
+      // We got the error we wanted. Test passed!
+      done();
+    });
+  });
+
+  it("even if we receive a runtime error, logs for successful transactions need to be processed", function(done) {
+    var tx1, tx2, blockNumber, bytecode;
+
+    // Note: The two transactions queued in this test should exist within the same block.
+
+    stopMining().then(function() {
+      return queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
+    }).then(function(tx) {
+      tx1 = tx;
+      return queueTransaction(accounts[0], null, 1000000, 0, goodBytecode);
+    }).then(function(tx) {
+      tx2 = tx;
+      return startMining();
+    }).then(function() {
+      throw new Error("Execution should never get here as we expected `miner_start` to throw an error")
+    }).catch(function(err) {
+      if (err.message.indexOf("VM Exception while processing transaction") != 0) {
+        return done(new Error("Received error we didn't expect: " + err));
+      }
+      // We got the error we wanted. Now check to see if the transaction was processed correctly.
+      getReceipt(tx2).then(function(receipt) {
+        // We should have a receipt for the second transaction - it should have been processed.
+        assert.notEqual(receipt, null);
+        // It also should have logs.
+        assert.notEqual(receipt.logs.length, 0);
+
+        // Now check that there's code at the address, which means it deployed successfully.
+        return getCode(receipt.contractAddress);
+      }).then(function(code) {
+        // Convert hex to a big number and ensure it's not zero.
+        assert(web3.toBigNumber(code).eq(0) == false);
+
+        // Hot diggety dog!
+        done();
+      });
     });
   });
 });

--- a/test/mining.js
+++ b/test/mining.js
@@ -11,13 +11,13 @@ describe("Block Processing", function() {
   var goodBytecode;
 
   before("compile solidity code that causes runtime errors", function() {
-    return compileSolidity("contract Example { function Example() {throw;} }").then(function(result) {
+    return compileSolidity("pragma solidity ^0.4.2; contract Example { function Example() {throw;} }").then(function(result) {
       badBytecode = "0x" + result.code;
     });
   });
 
   before("compile solidity code that causes an event", function() {
-    return compileSolidity("contract Example { event Event(); function Example() { Event(); } }").then(function(result) {
+    return compileSolidity("pragma solidity ^0.4.2; contract Example { event Event(); function Example() { Event(); } }").then(function(result) {
       goodBytecode = "0x" + result.code;
     });
   });

--- a/test/mining.js
+++ b/test/mining.js
@@ -1,0 +1,172 @@
+var Web3 = require('web3');
+var TestRPC = require("../index.js");
+var assert = require('assert');
+var to = require("../lib/utils/to.js");
+
+describe("Block Processing", function() {
+  var web3 = new Web3(TestRPC.provider());
+  var accounts;
+
+  // Everything's a Promise to add in readibility.
+
+  function getBlockNumber() {
+    return new Promise(function(accept, reject) {
+      web3.eth.getBlockNumber(function(err, number) {
+        if (err) return reject(err);
+        accept(to.number(number));
+      });
+    });
+  };
+
+  function startMining() {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_start",
+        params: [1],
+        id: new Date().getTime()
+      }, function(err) {
+        if (err) return reject(err);
+        accept();
+      });
+    });
+  }
+
+  function stopMining() {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+        id: new Date().getTime()
+      }, function(err) {
+        if (err) return reject(err);
+        accept();
+      });
+    });
+  }
+
+  function queueTransaction(from, to, gasLimit, value) {
+    return new Promise(function(accept, reject) {
+      web3.eth.sendTransaction({
+        from: from,
+        to: to,
+        gas: gasLimit,
+        value: value
+      }, function(err, tx) {
+        if (err) return reject(err);
+        accept(tx);
+      });
+    })
+  }
+
+  function getReceipt(tx) {
+    return new Promise(function(accept, reject) {
+      web3.eth.getTransactionReceipt(tx, function(err, result) {
+        if (err) return reject(err);
+        accept(result);
+      });
+    });
+  };
+
+  before(function(done) {
+    web3.eth.getAccounts(function(err, accs) {
+      if (err) return done(err);
+      accounts = accs;
+      done();
+    });
+  });
+
+  it("should mine a single block with two queued transactions", function() {
+    var tx1, tx2, blockNumber;
+
+    return stopMining().then(function() {
+      return getBlockNumber();
+    }).then(function(number) {
+      blockNumber = number;
+      return queueTransaction(accounts[0], accounts[1], 90000, web3.toWei(2, "Ether"));
+    }).then(function(tx) {
+      tx1 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return queueTransaction(accounts[0], accounts[1], 90000, web3.toWei(3, "Ether"));
+    }).then(function(tx) {
+      tx2 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return startMining();
+    }).then(function() {
+      return Promise.all([getReceipt(tx1), getReceipt(tx2)]);
+    }).then(function(receipts) {
+      assert.equal(receipts.length, 2);
+      assert.notEqual(receipts[0], null);
+      assert.equal(receipts[0].transactionHash, tx1);
+      assert.notEqual(receipts[1], null);
+      assert.equal(receipts[1].transactionHash, tx2);
+
+      return getBlockNumber();
+    }).then(function(number) {
+      assert.equal(number, blockNumber + 1);
+    });
+  });
+
+  it("should mine two blocks when two queued transactions won't fit into a single block", function() {
+    // This is a very similar test to the above, except the gas limits are much higher
+    // per transaction. This means the TestRPC will react differently and process
+    // each transaction it its own block.
+
+    var tx1, tx2, blockNumber;
+
+    return stopMining().then(function() {
+      return getBlockNumber();
+    }).then(function(number) {
+      blockNumber = number;
+      return queueTransaction(accounts[0], accounts[1], 4000000, web3.toWei(2, "Ether"));
+    }).then(function(tx) {
+      tx1 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return queueTransaction(accounts[0], accounts[1], 4000000, web3.toWei(3, "Ether"));
+    }).then(function(tx) {
+      tx2 = tx;
+      return getReceipt(tx);
+    }).then(function(receipt) {
+      assert.equal(receipt, null);
+
+      return startMining();
+    }).then(function() {
+      return Promise.all([getReceipt(tx1), getReceipt(tx2)]);
+    }).then(function(receipts) {
+      assert.equal(receipts.length, 2);
+      assert.notEqual(receipts[0], null);
+      assert.equal(receipts[0].transactionHash, tx1);
+      assert.notEqual(receipts[1], null);
+      assert.equal(receipts[1].transactionHash, tx2);
+
+      return getBlockNumber();
+    }).then(function(number) {
+      assert.equal(number, blockNumber + 2);
+    });
+  });
+
+  it("should error if queued transaction exceeds the block gas limit", function(done) {
+    return stopMining().then(function() {
+      return queueTransaction(accounts[0], accounts[1], 5000000, web3.toWei(2, "Ether"));
+    }).then(function(tx) {
+      // It should never get here.
+      return done(new Error("Transaction was processed without erroring; gas limit should have been too high"));
+    }).catch(function(err) {
+      // We caught an error like we expected. Ensure it's the right error, or rethrow.
+      if (err.message.toLowerCase().indexOf("exceeds block gas limit") < 0) {
+        return done(new Error("Did not receive expected error; instead received: " + err));
+      }
+
+      done();
+    });
+  });
+});

--- a/test/mining.js
+++ b/test/mining.js
@@ -81,6 +81,19 @@ describe("Block Processing", function() {
     });
   }
 
+  function checkMining() {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "eth_mining",
+        id: new Date().getTime()
+      }, function(err, res) {
+        if (err) return reject(err);
+        accept(res.result);
+      });
+    });
+  }
+
   function mineSingleBlock() {
     return new Promise(function(accept, reject) {
       web3.currentProvider.sendAsync({
@@ -394,6 +407,19 @@ describe("Block Processing", function() {
         // Hot diggety dog!
         done();
       });
+    });
+  });
+
+  it("should return the correct value for eth_mining when miner started and stopped", function() {
+    return stopMining().then(function() {
+      return checkMining();
+    }).then(function(is_mining) {
+      assert(!is_mining);
+      return startMining();
+    }).then(function() {
+      return checkMining();
+    }).then(function(is_mining) {
+      assert(is_mining);
     });
   });
 });

--- a/test/queuedTransactions.js
+++ b/test/queuedTransactions.js
@@ -1,0 +1,91 @@
+var Web3 = require('web3');
+var TestRPC = require("../index.js");
+var assert = require('assert');
+
+
+
+var accounts;
+var web3 = new Web3(TestRPC.provider());
+
+before(function(done) {
+  web3.eth.getAccounts(function(err, accs) {
+    if (err) return done(err);
+
+    accounts = accs;
+    done();
+  });
+});
+
+beforeEach(function(done){
+  web3.currentProvider.sendAsync({
+    jsonrpc: "2.0",
+    method: "miner_stop",
+  }, done)
+});
+
+afterEach(function(done){
+  web3.currentProvider.sendAsync({
+    jsonrpc: "2.0",
+    method: "miner_start",
+    params: [1]
+  }, done)
+});
+
+
+describe("Ordering transactions", function() {
+  it("should order queued transactions correctly by nonce before adding to the block", function(done) {
+    var tx_data = {}
+    tx_data.to = accounts[1];
+    tx_data.from = accounts[0];
+    tx_data.value = 0x1;
+    tx_data.nonce = 0;
+    tx_data.gas = 21000;
+    web3.eth.sendTransaction(tx_data, function(err, tx) {
+      if (err){return done(err)}
+      tx_data.nonce=1;
+      web3.eth.sendTransaction(tx_data, function(err, tx){
+        if (err){return done(err)}
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,tx){
+          web3.eth.getBlock("latest", function(err, block) {
+            if (err) return done(err);
+            assert.equal(block.transactions.length, 2, "Latest block should have two transactions");
+            done();
+          });
+        })
+      })
+    })
+  });
+  it("should order queued transactions correctly by price before adding to the block", function(done) {
+    var tx_data = {}
+    tx_data.to = accounts[1];
+    tx_data.from = accounts[0];
+    tx_data.value = 0x1;
+    tx_data.gas = 21000;
+    tx_data.gasPrice = 0x1
+    web3.eth.sendTransaction(tx_data, function(err, tx) {
+      if (err){return done(err)}
+      tx_data.gasPrice=2;
+      tx_data.from = accounts[1];
+      web3.eth.sendTransaction(tx_data, function(err, tx){
+        if (err){return done(err)}
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,tx){
+          web3.eth.getBlock("latest", function(err, block) {
+            if (err) return done(err);
+            assert.equal(block.transactions.length, 2, "Latest block should have two transactions");
+            assert.equal(block.transactions[0].gasPrice.toNumber(),2)
+            assert.equal(block.transactions[1].gasPrice.toNumber(),1)
+            done();
+          });
+        })
+      })
+    })
+  });
+});

--- a/test/queuedTransactions.js
+++ b/test/queuedTransactions.js
@@ -2,37 +2,34 @@ var Web3 = require('web3');
 var TestRPC = require("../index.js");
 var assert = require('assert');
 
-
-
-var accounts;
-var web3 = new Web3(TestRPC.provider());
-
-before(function(done) {
-  web3.eth.getAccounts(function(err, accs) {
-    if (err) return done(err);
-
-    accounts = accs;
-    done();
-  });
-});
-
-beforeEach(function(done){
-  web3.currentProvider.sendAsync({
-    jsonrpc: "2.0",
-    method: "miner_stop",
-  }, done)
-});
-
-afterEach(function(done){
-  web3.currentProvider.sendAsync({
-    jsonrpc: "2.0",
-    method: "miner_start",
-    params: [1]
-  }, done)
-});
-
-
 describe("Ordering transactions", function() {
+  var accounts;
+  var web3 = new Web3(TestRPC.provider());
+
+  before(function(done) {
+    web3.eth.getAccounts(function(err, accs) {
+      if (err) return done(err);
+
+      accounts = accs;
+      done();
+    });
+  });
+
+  beforeEach(function(done){
+    web3.currentProvider.sendAsync({
+      jsonrpc: "2.0",
+      method: "miner_stop",
+    }, done)
+  });
+
+  afterEach(function(done){
+    web3.currentProvider.sendAsync({
+      jsonrpc: "2.0",
+      method: "miner_start",
+      params: [1]
+    }, done)
+  });
+
   it("should order queued transactions correctly by nonce before adding to the block", function(done) {
     var tx_data = {}
     tx_data.to = accounts[1];
@@ -59,6 +56,7 @@ describe("Ordering transactions", function() {
       })
     })
   });
+  
   it("should order queued transactions correctly by price before adding to the block", function(done) {
     var tx_data = {}
     tx_data.to = accounts[1];

--- a/test/requests.js
+++ b/test/requests.js
@@ -5,6 +5,7 @@ var assert = require('assert');
 var TestRPC = require("../index.js");
 var solc = require("solc");
 var fs = require("fs");
+var to = require("../lib/utils/to");
 
 var source = fs.readFileSync("./test/Example.sol", {encoding: "utf8"});
 var result = solc.compile(source, 1);
@@ -31,7 +32,8 @@ var contract = {
   transaction_data: {
     from: null, // set by test
     to: null, // set by test
-    data: '0x552410770000000000000000000000000000000000000000000000000000000000000019' // sets value to 25 (base 10)
+    data: '0x552410770000000000000000000000000000000000000000000000000000000000000019', // sets value to 25 (base 10)
+    gas: 3141592
   }
 };
 
@@ -172,7 +174,8 @@ var tests = function(web3) {
     it("should return transactions in the block as well", function(done) {
       web3.eth.sendTransaction({
         from: accounts[0],
-        data: contract.binary
+        data: contract.binary,
+        gas: 3141592
       }, function(err, tx_hash) {
         if (err) return done(err);
 
@@ -236,7 +239,8 @@ var tests = function(web3) {
     it("should add a contract to the network (eth_sendTransaction)", function(done) {
       web3.eth.sendTransaction({
         from: accounts[0],
-        data: contract.binary
+        data: contract.binary,
+        gas: 3141592
       }, function(err, result) {
         if (err) return done(err);
 
@@ -344,7 +348,7 @@ var tests = function(web3) {
     it("should represent the block number correctly in the Oracle contract (oracle.blockhash0)", function(done){
       var oracleSol = fs.readFileSync("./test/Oracle.sol", {encoding: "utf8"});
       var oracleOutput = solc.compile(oracleSol).contracts.Oracle
-      web3.eth.contract(JSON.parse(oracleOutput.interface)).new({ data: oracleOutput.bytecode, from: accounts[0] }, function(err, oracle){
+      web3.eth.contract(JSON.parse(oracleOutput.interface)).new({ data: oracleOutput.bytecode, from: accounts[0], gas: 3141592 }, function(err, oracle){
         if(err) return done(err)
         if(!oracle.address) return
         web3.eth.getBlock(0, function(err, block){
@@ -477,6 +481,7 @@ var tests = function(web3) {
 
     var tx = new Transaction({
       data: contract.binary,
+      gasLimit: to.hex(3141592)
     })
     var privateKey = new Buffer('e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109', 'hex')
     var senderAddress = '0x'+utils.privateToAddress(privateKey).toString('hex')
@@ -495,6 +500,7 @@ var tests = function(web3) {
         from: accounts[0],
         to: senderAddress,
         value: '0x3141592',
+        gas: 3141592
       }, function(err, result) {
         if (err) return done(err);
         done();

--- a/test/requests.js
+++ b/test/requests.js
@@ -377,7 +377,7 @@ var tests = function(web3) {
 
         web3.eth.estimateGas(tx_data, function(err, result) {
           if (err) return done(err);
-          assert.equal(result, 27626);
+          assert.equal(result, 27641);
 
           web3.eth.getBlockNumber(function(err, result) {
             if (err) return done(err);
@@ -398,7 +398,7 @@ var tests = function(web3) {
 
       web3.eth.estimateGas(tx_data, function(err, result) {
         if (err) return done(err);
-        assert.equal(result, 27626);
+        assert.equal(result, 27641);
         done();
       });
     });
@@ -412,7 +412,7 @@ var tests = function(web3) {
 
       web3.eth.estimateGas(tx_data, function(err, result) {
         if (err) return done(err);
-        assert.equal(result, 27626);
+        assert.equal(result, 27641);
         done();
       });
     });

--- a/test/requests.js
+++ b/test/requests.js
@@ -611,7 +611,6 @@ var tests = function(web3) {
           tx_data.from = accounts[0];
           tx_data.value = 0x1;
 
-
           web3.eth.sendTransaction(tx_data, function(err, tx) {
             if (err) return done(err);
             //Check the receipt

--- a/test/requests.js
+++ b/test/requests.js
@@ -563,6 +563,69 @@ var tests = function(web3) {
     });
   });
 
+  describe("miner_stop", function(){
+    it("should stop mining", function(done){
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+      }, function(err,result){
+        var tx_data = {}
+        tx_data.to = accounts[1];
+        tx_data.from = accounts[0];
+        tx_data.value = 0x1;
+
+        web3.eth.sendTransaction(tx_data, function(err, tx) {
+          if (err) return done(err);
+
+          web3.eth.getTransactionReceipt(tx, function(err, receipt) {
+            if (err) return done(err);
+
+            assert.equal(receipt, null);
+            web3.currentProvider.sendAsync({
+              jsonrpc: "2.0",
+              method: "miner_start",
+              params: [1]
+            }, function(err, result){
+              if (err) return done(err);
+              done();
+            })
+          });
+        });
+      })
+    })
+  });
+
+  describe("miner_start", function(){
+    it("should start mining", function(done){
+      web3.currentProvider.sendAsync({
+        jsonrpc: "2.0",
+        method: "miner_stop",
+      }, function(err,result){
+        web3.currentProvider.sendAsync({
+          jsonrpc: "2.0",
+          method: "miner_start",
+          params: [1]
+        }, function(err,result){
+          var tx_data = {}
+          tx_data.to = accounts[1];
+          tx_data.from = accounts[0];
+          tx_data.value = 0x1;
+
+
+          web3.eth.sendTransaction(tx_data, function(err, tx) {
+            if (err) return done(err);
+            //Check the receipt
+            web3.eth.getTransactionReceipt(tx, function(err, receipt) {
+              if (err) return done(err);
+              assert.notEqual(receipt, null); //i.e. receipt exists, so transaction was mined
+              done();
+            });
+          });
+        })
+      })
+    })
+  });
+
   describe("web3_sha3", function() {
     it("should hash the given input", function(done) {
       var input = "Tim is a swell guy.";

--- a/test/requests.js
+++ b/test/requests.js
@@ -101,11 +101,11 @@ var tests = function(web3) {
   });
 
   describe("eth_gasPrice", function() {
-    it("should return gas price of 1", function(done) {
+    it("should return gas price of 0.02 szabo", function(done) {
       web3.eth.getGasPrice(function(err, result) {
         if (err) return done(err);
 
-        assert.deepEqual(result.toNumber(), 1);
+        assert.deepEqual(result.toNumber(), 20000000000);
         done();
       });
     });

--- a/test/transaction_ordering.js
+++ b/test/transaction_ordering.js
@@ -2,7 +2,7 @@ var Web3 = require('web3');
 var TestRPC = require("../index.js");
 var assert = require('assert');
 
-describe("Ordering transactions", function() {
+describe("Transaction Ordering", function() {
   var accounts;
   var web3 = new Web3(TestRPC.provider());
 
@@ -56,7 +56,7 @@ describe("Ordering transactions", function() {
       })
     })
   });
-  
+
   it("should order queued transactions correctly by price before adding to the block", function(done) {
     var tx_data = {}
     tx_data.to = accounts[1];


### PR DESCRIPTION
- Default gas price is now 0.02 szabo, mimicking geth
- Default gas limit for transactions is now 90000 wei instead of the full block gas limit. This also mimicks geth, and sets users up for deploying to live blockchains.
- Added `miner_start`/`miner_stop` support, which toggles mining and allows transactions to be queued when mining is off
- Added `rpc_modules` request, for use with `geth attach`
- Added support for `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex` requests.
- Block processing has been significantly improved. Queued transactions are now ordered by price, nonce and gas limit, like geth, and the TestRPC will attempt to fit as many transactions in a block as possible.
- There are now three block processing strategies available: instamine (default behavior), mine on interval (`--blocktime`), and mine by request (`miner_stop` + transaction queuing + multiple `evm_mine` requests). Besides `--blocktime`, you can stop the miner whenever you'd like and continue to queue transactions; sending an `evm_mine` request will make TestRPC process one block with as many transactions as it can fit. Huge thanks to @area 
- `--blocktime` is now disjointed from instamining. If you specify `--blocktime`, transactions will **only** be processed on the interval, and won't be instamined (unlike 2.x behavior). This can make the TestRPC seem like a real blockchain. Note that errors aren't returned in transaction requests since block processing is disjoint from transactions.
- Transaction errors are now printed to the TestRPC log.
- Added `--secure` flag, which automatically makes defaults all accounts to be locked, meaning transactions won't be signed by the TestRPC. This is useful if you want to ensure signing is working properly through another mechanism (like Metamask) and you want to be sure TestRPC isn't performing the signing.
- Added `--unlock`/`-u` flags, which can be used any number of times to unlock **any** account, passing in a 0x-prefixed address or an account index. When used with `--secure` you can unlock accounts that are created for you via the TestRPC; when used with `--fork` you can use this feature to "impersonate" accounts on the blockchain, allowing you to bypass transaction signing and use that address as if you owned it.
- Error handling has been overhauled to support multiple transactions per block and therefore multiple errors per `evm_mine` request (when using `miner_start`/`miner_stop` and transaction queuing)
- Fixed issue with `-a` not working properly.
- Upgrade `solc` version to 0.4.x
- Tons more tests.
