### PR TITLE
declare blockNumber

### DIFF
--- a/lib/subproviders/delayedblockfilter.js
+++ b/lib/subproviders/delayedblockfilter.js
@@ -50,6 +50,7 @@ DelayedBlockFilter.prototype.handleGetFilterChanges = function(payload, next, en
 
     var currentBlockHash;
     var previousBlockHash;
+    var blockNumber;
 
     async.series([
       function(c) {


### PR DESCRIPTION
address ReferenceError

> ReferenceError: blockNumber is not defined
>    at async.series.previousBlockHash (/testrpc/lib/subproviders/delayedblockfilter.js:76:21)
