### PR TITLE
Fix eth_sign bug (Issue #190)

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -368,13 +368,7 @@ StateManager.prototype.sign = function(address, dataToSign) {
 
   var secretKey = account.secretKey;
   var sgn = utils.ecsign(new Buffer(dataToSign.replace('0x',''), 'hex'), new Buffer(secretKey));
-  var r = utils.fromSigned(sgn.r);
-  var s = utils.fromSigned(sgn.s);
-  var v = utils.bufferToInt(sgn.v) - 27;
-  r = utils.toUnsigned(r).toString('hex');
-  s = utils.toUnsigned(s).toString('hex');
-  v = utils.stripHexPrefix(utils.intToHex(v));
-  return utils.addHexPrefix(r.concat(s, v));
+  return utils.toRpcSig(sgn.v, sgn.r, sgn.s);
 };
 
 StateManager.prototype.printTransactionReceipt = function(tx_hash, error, callback){


### PR DESCRIPTION
eth_sign currently fails if ecsign returns 'r' or 's' components that have leading zeros. This PR replaces existing logic that translates ecsign output to  rpc format with ethereumjs-utils `toRpcSig` method.  
