### PR TITLE
include_full_transactions fix

### DIFF
--- a/lib/BlockStub.js
+++ b/lib/BlockStub.js
@@ -1,0 +1,1 @@
+module.exports = function DefaultBlockStub () {}

--- a/lib/BlockStub.js
+++ b/lib/BlockStub.js
@@ -1,1 +1,0 @@
-module.exports = function DefaultBlockStub () {}

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -115,7 +115,7 @@ GethApiDouble.prototype.eth_getCode = function(address, block_number, callback) 
   this.state.getCode(address, block_number, callback);
 };
 
-GethApiDouble.prototype.eth_getBlockByNumber = function(block_number, include_transactions, callback) {
+GethApiDouble.prototype.eth_getBlockByNumber = function(block_number, include_full_transactions, callback) {
   this.state.blockchain.getBlock(block_number, function(err, block) {
     if (err) return callback(err);
 
@@ -137,13 +137,19 @@ GethApiDouble.prototype.eth_getBlockByNumber = function(block_number, include_tr
       gasLimit: to.hex(block.header.gasLimit),
       gasUsed: to.hex(block.header.gasUsed),
       timestamp: to.hex(block.header.timestamp),
-      transactions: block.transactions.map(function(tx) {return txhelper.toJSON(tx, block)}),
+      transactions: block.transactions.map(function(tx) {
+        if (include_full_transactions) {
+          return txhelper.toJSON(tx, block);
+        } else {
+          return to.hex(tx.hash());
+        }
+      }),
       uncles: []//block.uncleHeaders.map(function(uncleHash) {return to.hex(uncleHash)})
     });
   });
 };
 
-GethApiDouble.prototype.eth_getBlockByHash = function(tx_hash, include_transactions, callback) {
+GethApiDouble.prototype.eth_getBlockByHash = function(tx_hash, include_full_transactions, callback) {
   this.eth_getBlockByNumber.apply(this, arguments);
 };
 

--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -138,7 +138,7 @@ ForkedBlockchain.prototype.getBlock = function(number, callback) {
   }
 
   function getFallbackBlock(number_or_hash, cb) {
-    self.web3.eth.getBlock(number_or_hash, function(err, json) {
+    self.web3.eth.getBlock(number_or_hash, true, function(err, json) {
       if (err) return cb(err);
 
       if (json == null) return cb();

--- a/test/forking.js
+++ b/test/forking.js
@@ -510,10 +510,10 @@ describe("Forking", function() {
     forkedWeb3.eth.getTransactionReceipt(initialDeployTransactionHash, function(err, receipt) {
       if (err) return done(err);
 
-      forkedWeb3.eth.getBlock(receipt.blockNumber, function(err, referenceBlock) {
+      forkedWeb3.eth.getBlock(receipt.blockNumber, true, function(err, referenceBlock) {
         if (err) return done(err);
 
-        mainWeb3.eth.getBlock(receipt.blockNumber, function(err, forkedBlock) {
+        mainWeb3.eth.getBlock(receipt.blockNumber, true, function(err, forkedBlock) {
           if (err) return done(err);
 
           assert.equal(forkedBlock.transactions.length, referenceBlock.transactions.length)

--- a/test/requests.js
+++ b/test/requests.js
@@ -135,7 +135,7 @@ var tests = function(web3) {
 
   describe("eth_getBlockByNumber", function() {
     it("should return block given the block number", function(done) {
-      web3.eth.getBlock(0, function(err, block) {
+      web3.eth.getBlock(0, true, function(err, block) {
         if (err) return done(err);
 
         var expectedFirstBlock = {
@@ -182,13 +182,21 @@ var tests = function(web3) {
         // Assume it was processed correctly.
         assert.deepEqual(tx_hash.length, 66);
 
-        web3.eth.getBlock("latest", function(err, block) {
+        web3.eth.getBlock("latest", true, function(err, block) {
           if (err) return done(err);
 
           assert.equal(block.transactions.length, 1, "Latest block should have one transaction");
           assert.equal(block.transactions[0].hash, tx_hash, "Transaction hashes don't match");
 
-          done();
+          //Retest, with transaction only as hash
+          web3.eth.getBlock("latest", false, function(err, block) {
+            if (err) return done(err);
+
+            assert.equal(block.transactions.length, 1, "Latest block should have one transaction");
+            assert.equal(block.transactions[0], tx_hash, "Transaction hashes don't match");
+
+            done()
+          });
         });
       });
     });
@@ -197,10 +205,10 @@ var tests = function(web3) {
   // Relies on the validity of eth_getBlockByNumber above.
   describe("eth_getBlockByHash", function() {
     it("should return block given the block hash", function(done) {
-      web3.eth.getBlock(0, function(err, blockByNumber) {
+      web3.eth.getBlock(0, true, function(err, blockByNumber) {
         if (err) return done(err);
 
-        web3.eth.getBlock(blockByNumber.hash, function(err, blockByHash) {
+        web3.eth.getBlock(blockByNumber.hash, true, function(err, blockByHash) {
           if (err) return done(err);
 
           assert.deepEqual(blockByHash, blockByNumber);
@@ -395,7 +403,7 @@ var tests = function(web3) {
       web3.eth.contract(JSON.parse(oracleOutput.interface)).new({ data: oracleOutput.bytecode, from: accounts[0], gas: 3141592 }, function(err, oracle){
         if(err) return done(err)
         if(!oracle.address) return
-        web3.eth.getBlock(0, function(err, block){
+        web3.eth.getBlock(0, true, function(err, block){
           if (err) return done(err)
           oracle.blockhash0(function(err, blockhash){
             if (err) return done(err)

--- a/test/transaction_ordering.js
+++ b/test/transaction_ordering.js
@@ -75,7 +75,7 @@ describe("Transaction Ordering", function() {
           method: "miner_start",
           params: [1]
         }, function(err,tx){
-          web3.eth.getBlock("latest", function(err, block) {
+          web3.eth.getBlock("latest", true, function(err, block) {
             if (err) return done(err);
             assert.equal(block.transactions.length, 2, "Latest block should have two transactions");
             assert.equal(block.transactions[0].gasPrice.toNumber(),2)


### PR DESCRIPTION
`getBlockByHash` and `getBlockByNumber` should only return full transaction objects when the 2nd parameter is true. web3 sets it to false by default.