### PR TITLE
adding some verbose logging and error logging

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -21,7 +21,8 @@ var Interface = {
 
     if (options.logger == null) {
       options.logger = {
-        log: function() {}
+        log: function() {},
+        error: function() {}
       };
     }
 
@@ -35,7 +36,7 @@ var Interface = {
       var body = [];
 
       request.on('error', function(err) {
-        // console.error(err);
+        logger.error(err);
       }).on('data', function(chunk) {
         body.push(chunk);
       }).on('end', function() {
@@ -56,7 +57,9 @@ var Interface = {
             response.end("");
             break;
           case "POST":
-            //console.log("Request coming in:", body);
+            if (options.verbose) {
+              logger.log(JSON.stringify({"headers": request.headers, "body": body }));
+            }
 
             var payload;
             try {
@@ -137,7 +140,8 @@ var Interface = {
 
     if (options.logger == null) {
       options.logger = {
-        log: function() {}
+        log: function() {},
+        error: function() {}
       };
     }
 


### PR DESCRIPTION
This adds some logging when verbose is on (config.verbose) and also in an error situation when the request is received, it uses the logger.error method that was added to the code; which only had logger.log prior. 

This has been helpful for debugging client calls in some things we are testing.