### PR TITLE
Update Dockerfile base to alpine-node:6.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:5.10
+FROM mhart/alpine-node:6.9.2
 
 WORKDIR /src
 ADD . .


### PR DESCRIPTION
The test suite fails to run inside the Docker image on alpine-node:5.10.

Steps to reproduce:
```
docker build -t testrpc .
docker run -it --entrypoint "/bin/bash" testrpc
```
And then, inside the container, `npm test`.

Furthermore, the README notes "As of version 3.0.2, testrpc requires at least Node 6.9.1 to run". In this PR all tests pass after following the same steps above.