### PR TITLE
Re-arranges the Dockerfile to improve performance.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM mhart/alpine-node:6.9.2
 
-WORKDIR /src
-ADD . .
-
 RUN apk add --no-cache make gcc g++ python git bash
+COPY package.json /src/package.json
+WORKDIR /src
 RUN npm install
+
+ADD . .
 
 EXPOSE 8545
 


### PR DESCRIPTION
Docker caches each line as a separate layer.  By putting the APK stuff first, docker will cache the results and not have to re-execute that line on subsequent builds.  By only copying `package.json` and running `npm install`, docker will cache a layer with just the result of those two commands so future `docker build`s will not have to re-run `npm install` unless `package.json` changes (in which case Docker's cache will be busted and a new cache layer created).

These changes allow developers to iterate very rapidly using Docker for running tests.  For example, to run tests after making source/test changes one can do:
`docker build -t testrpc . && docker run --rm --entrypoint=npm testrpc test`
With the restructured `Dockerfile`, this command takes seconds to execute and doesn't require that the developer have the necessary environment setup locally (other than having docker installed).  Prior to this change, executing the above command would take quite a while as the docker image needed to be rebuilt from scratch and NPM dependencies re-evaluated from scratch.