### PR TITLE
Implement cpp-ethereum's test RPC API [WIP]

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -298,7 +298,7 @@ GethApiDouble.prototype.miner_stop = function(callback) {
 
 GethApiDouble.prototype.rpc_modules = function(callback) {
   // returns the availible api modules and versions
-  callback(null, {"eth":"1.0","net":"1.0","rpc":"1.0","web3":"1.0","evm":"1.0"});
+  callback(null, {"eth":"1.0","net":"1.0","rpc":"1.0","web3":"1.0","evm":"1.0","test":"1.0"});
 };
 
 /* Functions for testing purposes only. */
@@ -322,6 +322,62 @@ GethApiDouble.prototype.evm_mine = function(callback) {
   });
 };
 
+/* cpp-ethereum specific methods, used by Solidity tests */
 
+var test_blocks = {}
+
+GethApiDouble.prototype.test_setChainParams = function(chain, callback) {
+  var self = this;
+  Object.keys(chain.accounts).forEach(function(address) {
+    var account = self.state.accounts[address];
+    if (account) {
+      // FIME: support changing balance of associated account
+      // self.state.blockchain.setBalance(address, chain.accounts[address].wei);
+      // account.account.balance = chain.accounts[address].wei;
+    }
+  });
+
+  // rewire block gas limit
+  self.state.blockchain.blockGasLimit = chain.genesis.gasLimit;
+
+  var blockNo = this.state.blockchain.blocks.length;
+  test_blocks[blockNo] = this.state.snapshot();
+
+  callback(null, true);
+};
+
+GethApiDouble.prototype.test_rewindToBlock = function(number, callback) {
+  number = number + 1
+
+  if (test_blocks[number] === undefined) {
+    callback("Block not found");
+  }
+
+  this.state.revert(test_blocks[number]);
+
+  callback(null, true);
+};
+
+GethApiDouble.prototype.test_mineBlocks = function(count, callback) {
+  var self = this;
+
+  var blockNo = this.state.blockchain.blocks.length;
+  test_blocks[blockNo] = this.state.snapshot();
+
+  this.state.blockchain.processNextBlock(function(err) {
+    if (err) {
+      callback(err);
+    } else if (--count > 0) {
+      // More to mine.
+      self.test_mineBlocks(count, callback);
+    } else {
+      // All blocks mined.
+      callback(null, true);
+    }
+  });
+};
+
+// FIXME: implement addBlock(rlp)
+// FIXME: implement modifyTimestamp(timestamp)
 
 module.exports = GethApiDouble;


### PR DESCRIPTION
This API is used by Solidity's soltest (the testing architecture) and https://github.com/ethereum/ethereum-console

Also see: https://github.com/ethereum/interfaces/issues/4