### PR TITLE
Stub for eth_protocolVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The RPC methods currently implemented are:
 * `eth_mining`
 * `eth_newBlockFilter`
 * `eth_newFilter` (includes log/event filters)
+* `eth_protocolVersion` (stub, returns -1)
 * `eth_sendTransaction`
 * `eth_sendRawTransaction`
 * `eth_sign`

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -273,6 +273,10 @@ GethApiDouble.prototype.eth_syncing = function(callback) {
   callback(null, false);
 };
 
+GethApiDouble.prototype.eth_protocolVersion = function(callback) {
+  callback(null, "-1");
+};
+
 GethApiDouble.prototype.net_listening = function(callback) {
   callback(null, true);
 };


### PR DESCRIPTION
Implements RPC method `eth_protocolVersion` returning `-1`.

This is just so we don't get an error as some of our internal tools call this method.