### PR TITLE
stop_server testrpc function to allow integration with test suites like karma

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -344,6 +344,13 @@ GethApiDouble.prototype.evm_mine = function(callback) {
   });
 };
 
+GethApiDouble.prototype.stop_server = function(callback) {
+  setTimeout(function(){
+    process.exit(0);
+  }, 5000);
+  callback(null, "stoping");
+};
+
 
 
 module.exports = GethApiDouble;


### PR DESCRIPTION
In nodejs we can import the testrpc provider as a library, but in javascript this cannot be done, it needs to run a server instance, so this function allows to use testrpc integrated with karma and start/stop the server on each test.