### PR TITLE
Output gas usage and block number as decimal integers instead of hex

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -392,8 +392,8 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, error, callba
         self.logger.log("  Contract created: " + receipt.contractAddress);
       }
 
-      self.logger.log("  Gas usage: " + receipt.gasUsed);
-      self.logger.log("  Block Number: " + receipt.blockNumber);
+      self.logger.log("  Gas usage: " + parseInt(receipt.gasUsed, 16));
+      self.logger.log("  Block Number: " + parseInt(receipt.blockNumber, 16));
       self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
 
       if (error) {


### PR DESCRIPTION
For easier readability of TestRPC console output values should be displayed as decimals.

**Before**
```
  Transaction: 0x7272b73e88a48520d84d61249f9f7eacc17d28ed0061f32d6f50e7bd4b77a0eb
  Contract created: 0x7047dbc603a495b72934576646eaf3487b038aae
  Gas usage: 0x0a2b36
  Block Number: 0x1f
  Block Time: Wed Mar 29 2017 12:37:33 GMT-0700 (PDT)
```

**After**
```
  Transaction: 0xcad2a0fc727b8eefabb22a65a2b85aa8ce7ce45de4d6920548753f65f7075e35
  Contract created: 0x6e61439cd1b446c797df188e1b996b07a36a298e
  Gas usage: 313298
  Block Number: 8
  Block Time: Wed Mar 29 2017 12:42:41 GMT-0700 (PDT)
```