### PR TITLE
Add `evm_coinbase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ There’s also special non-standard methods that aren’t included within the or
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.
 * `evm_increaseTime` : Jump forward in time. Takes one parameter, which is the amount of time to increase in seconds. Returns the total time adjustment, in seconds.
 * `evm_mine` : Force a block to be mined. Takes no parameters. Mines a block independent of whether or not mining is started or stopped.
+* `evm_coinbase` : Set the coinbase for mined blocks
 
 # Docker
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -36,6 +36,7 @@ function BlockchainDouble(options) {
   this.blockGasLimit = options.gasLimit || "0x47E7C4";
   this.defaultTransactionGasLimit = '0x15f90';
   this.timeAdjustment = 0;
+  this.coinbase = null;
 };
 
 BlockchainDouble.prototype.initialize = function(accounts, callback) {
@@ -281,6 +282,10 @@ BlockchainDouble.prototype.createBlock = function(callback) {
 
     // Set the timestamp before processing txs
     block.header.timestamp = to.hex(self.currentTime());
+
+    if (this.coinbase !== null) {
+      block.header.coinbase = to.hex(this.coinbase);
+    }
 
     if (parent != null) {
       block.header.parentHash = to.hex(parent.hash());
@@ -678,6 +683,10 @@ BlockchainDouble.prototype.setTime = function(date) {
 
 BlockchainDouble.prototype.close = function(callback) {
   this.data.close(callback);
+};
+
+BlockchainDouble.prototype.setCoinbase = function(address) {
+  this.coinbase = address;
 };
 
 module.exports = BlockchainDouble;

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -283,8 +283,8 @@ BlockchainDouble.prototype.createBlock = function(callback) {
     // Set the timestamp before processing txs
     block.header.timestamp = to.hex(self.currentTime());
 
-    if (this.coinbase !== null) {
-      block.header.coinbase = to.hex(this.coinbase);
+    if (self.coinbase !== null) {
+      block.header.coinbase = to.hex(self.coinbase);
     }
 
     if (parent != null) {

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -652,4 +652,10 @@ StateManager.prototype.isUnlocked = function(address) {
   return this.unlocked_accounts[address.toLowerCase()] != null;
 };
 
+StateManager.prototype.setCoinbase = function(address, callback) {
+  this.coinbase = address;
+  this.blockchain.setCoinbase(address);
+  callback();
+};
+
 module.exports = StateManager;

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -344,6 +344,9 @@ GethApiDouble.prototype.evm_mine = function(callback) {
   });
 };
 
+GethApiDouble.prototype.evm_coinbase = function(address, callback) {
+  this.state.setCoinbase(address, callback);
+};
 
 
 module.exports = GethApiDouble;


### PR DESCRIPTION
Adds a non-standard RPC method to set the coinbase for mined blocks.

Setting the coinbase allows for testing contracts that depend on `block.coinbase`, especially in the case where multiple miners are being tested.

NOTE: Unless this is called, the value returned by `eth_coinbase`
actually differs from the coinbase included in blocks. The default coinbase for
mined blocks is actually the null address, and I opted to not change it, so as to not introduce a breaking change.  BlockchainDouble never sets `block.header.coinbase` in `createBlock`, so the block's `miner` (coinbase) field is always the null address.

If the breaking change is fine, an alternative approach would be to remove `coinbase` from `StateManager` entirely, since it's only used for `eth_coinbase`, and isn't even accurate.  Instead, introduce a `getCoinbase` to `BlockchainDouble`, and delegate all interactions with coinbase to `BlockchainDouble`'s api.

Second note:  I haven't actually tested this against the current `master` HEAD, only against a [branch forked off from the v3.0.3 release](https://github.com/DeviateFish/testrpc/tree/v3.0.3-b). This is the same change ported to be compatible with the existing `master` branch.