### PR TITLE
Add header to cache CORS requests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,8 @@ module.exports = function(options) {
       var headers = {
         "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept",
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "*"
+        "Access-Control-Allow-Methods": "*",
+        "Access-Control-Max-Age": "300"
       };
 
       switch (method) {
@@ -77,6 +78,7 @@ module.exports = function(options) {
             "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept",
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Methods": "*",
+            "Access-Control-Max-Age": "300",
             "Content-Type": "text/plain"
           });
           response.end("400 Bad Request");


### PR DESCRIPTION
Now those preflight requests are not cached and executed before each call.
This causes performance problems if the DApp needs to fetch a lot of data.
This pool-request aims to fix that by introducing a 5 min caching for preflight CORS requests.
