### PR TITLE
Return null for future blocks

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -155,7 +155,15 @@ BlockchainDouble.prototype.getBlock = function(number, callback) {
       });
     } else {
       // Block number
-      return this.data.blocks.get(to.number(hash), callback);
+      return this.data.blocks.get(to.number(hash), function (err, block) {
+
+        // If block was out of range, return null:
+        if (err && err.message.includes('index out of range')) {
+          return callback(null, null);
+        }
+
+        return callback(err, block);
+      });
     }
   } else {
     if (number == "latest" || number == "pending") {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -131,6 +131,11 @@ GethApiDouble.prototype.eth_getBlockByNumber = function(block_number, include_fu
   this.state.blockchain.getBlock(block_number, function(err, block) {
     if (err) return callback(err);
 
+    // return null for future blocks:
+    if (!block) {
+      return callback(null, null)
+    }
+
     callback(null, {
       number: to.hex(block.header.number),
       hash: to.hex(block.hash()),

--- a/test/requests.js
+++ b/test/requests.js
@@ -184,6 +184,17 @@ var tests = function(web3) {
       });
     });
 
+
+    it("should return null given a future block number", function(done) {
+      web3.eth.getBlock(10000, true, function(err, block) {
+        if (err) return done(err);
+
+        assert.deepEqual(block, null);
+        done();
+      });
+    });
+
+
     it("should return transactions in the block as well", function(done) {
       web3.eth.sendTransaction({
         from: accounts[0],


### PR DESCRIPTION
Fixes #290 

Restores compatibility with provider-engine ^12.x.x.

Returns `null` when a future block is queried, just like parity and geth now do.