### PR TITLE
issue 300: adding missing functions so testrpc can work with redux-devtools

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -277,6 +277,26 @@ GethApiDouble.prototype.eth_uninstallFilter = function(filter_id, callback) {
   callback(null, true);
 };
 
+GethApiDouble.prototype.eth_protocolVersion = function(callback) {
+  callback(null, "63");
+};
+
+GethApiDouble.prototype.personal_listAccounts = function(callback) {
+  callback(null, Object.keys(this.state.accounts));
+};
+
+GethApiDouble.prototype.bzz_hive = function(callback) {
+  callback(null, []);
+};
+
+GethApiDouble.prototype.bzz_info = function(callback) {
+  callback(null, []);
+};
+
+GethApiDouble.prototype.shh_version = function(callback) {
+  callback(null, "2");
+};
+
 GethApiDouble.prototype.eth_getCompilers = function(callback) {
   callback(null, ["solidity"]);
 }

--- a/test/accounts.js
+++ b/test/accounts.js
@@ -20,6 +20,18 @@ describe("Accounts", function() {
     });
   });
 
+  it("should be equal (getListAccounts) and (getAccounts)", function(done) {
+    var web3 = new Web3();
+    web3.setProvider(TestRPC.provider());
+    web3.personal.getListAccounts(function(err, listAccounts) {
+      if (err) return done(err);
+      web3.eth.getAccounts(function(err, getAccounts){
+        assert.deepEqual(listAccounts, getAccounts);
+        done();
+      })
+    });
+  });
+
   it("should lock all accounts when specified", function(done) {
     var web3 = new Web3();
     web3.setProvider(TestRPC.provider({

--- a/test/ethereum.js
+++ b/test/ethereum.js
@@ -1,0 +1,21 @@
+var Web3 = require('web3');
+var assert = require('assert');
+var TestRPC = require("../index.js");
+
+
+describe("Ethereum", function(done) {
+  var web3 = new Web3();
+  var provider;
+
+  before("Initialize the provider", function() {
+    provider = TestRPC.provider();
+    web3.setProvider(provider);
+  });
+
+  it("should get ethereum version (eth_protocolVersion)", function(done) {
+    web3.version.getEthereum(function(err, result){
+      assert.equal(result, "63", "Network Version should be 63");
+      done();
+    })
+  });
+});

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -1,0 +1,27 @@
+var Web3 = require('web3');
+var assert = require('assert');
+var TestRPC = require("../index.js");
+
+describe("Swarm", function(done) {
+  var web3 = new Web3();
+  var provider;
+
+  before("Initialize the provider", function() {
+    provider = TestRPC.provider();
+    web3.setProvider(provider);
+  });
+
+  it.skip("should get swarm info (bzz_info)", function(done) {
+    web3.bzz.getInfo(function(err, result){
+      assert.isArray(result, "Stub returns empty array")
+      done();
+    })
+  });
+
+  it.skip("should get swarm hive (bzz_hive)", function(done) {
+    web3.bzz.getHive(function(err, result){
+      assert.isArray(result, "Stub returns empty array")
+      done();
+    })
+  });
+});

--- a/test/whisper.js
+++ b/test/whisper.js
@@ -1,0 +1,20 @@
+var Web3 = require('web3');
+var assert = require('assert');
+var TestRPC = require("../index.js");
+
+describe("Whisper", function(done) {
+  var web3 = new Web3();
+  var provider;
+
+  before("Initialize the provider", function() {
+    provider = TestRPC.provider();
+    web3.setProvider(provider);
+  });
+
+  it("should call get whisper version (shh_version)", function(done) {
+    web3.version.getWhisper(function(err, result){
+      assert.equal(result, "2", "Whisper version should be 2");
+      done();
+    })
+  });
+});


### PR DESCRIPTION
Request add missing rpc calls so redux-devtools works. 

1. eth_protocolVersion
2. personal_listAccounts
3. bzz_hive
4. bzz_info
5. ssh_version

Nothing is using those methods currently. 
@tcoulter 