### PR TITLE
Bump Node version to 7.9.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:5.10
+FROM mhart/alpine-node:7.9.0
 
 WORKDIR /src
 ADD . .


### PR DESCRIPTION
Fixes #302. 

Not sure if I am being too ambitious with going all the way to 7.9.0 but tests are passing and it seems to be working. 