### PR TITLE
Expose setTime to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ There’s also special non-standard methods that aren’t included within the or
 * `evm_snapshot` : Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the integer id of the snapshot created.
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.
 * `evm_increaseTime` : Jump forward in time. Takes one parameter, which is the amount of time to increase in seconds. Returns the total time adjustment, in seconds.
+* `evm_setTime` : Jump forward in time or reset any jumps set previously. Takes one parameter, which is anything parsable into a javascript date.
 * `evm_mine` : Force a block to be mined. Takes no parameters. Mines a block independent of whether or not mining is started or stopped.
 
 # Docker

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -337,6 +337,10 @@ GethApiDouble.prototype.evm_increaseTime = function(seconds, callback) {
   callback(null, this.state.blockchain.increaseTime(seconds));
 };
 
+GethApiDouble.prototype.evm_setTime = function(date, callback) {
+  callback(null, this.state.blockchain.setTime(new Date(date)));
+};
+
 GethApiDouble.prototype.evm_mine = function(callback) {
   this.state.blockchain.processNextBlock(function(err) {
     // Remove the VM result objects from the return value.

--- a/test/time_adjust.js
+++ b/test/time_adjust.js
@@ -41,7 +41,7 @@ describe('Time adjustment', function() {
     });
   });
 
-  it('should jump 5 hours', function(done) {
+  it('should jump 5 hours using increaseTime', function(done) {
     // Adjust time
     send("evm_increaseTime", [secondsToJump], function(err, result) {
       if (err) return done(err);
@@ -64,4 +64,41 @@ describe('Time adjustment', function() {
       })
     })
   })
+
+  it('should be able to reset back to current time', function(done) {
+    send("evm_setTime", [new Date().getTime()], function(err, result) {
+        // Mine a block so new time is recorded.
+        send("evm_mine", function(err, result) {
+            if (err) return done(err);
+
+            web3.eth.getBlock('latest', function(err, block){
+                if(err) return done(err)
+                var secondsJumped = block.timestamp - timestampBeforeJump
+                assert(secondsJumped >= secondsJumped)
+                done()
+            })
+        })
+    })
+  })
+
+    it('should jump 5 hours using setTime', function(done) {
+        // Adjust time
+        send("evm_setTime", [new Date().getTime() + secondsToJump * 1000], function(err, result) {
+            if (err) return done(err);
+
+            // Mine a block so new time is recorded.
+            send("evm_mine", function(err, result) {
+                if (err) return done(err);
+
+                web3.eth.getBlock('latest', function(err, block){
+                    if(err) return done(err)
+                    var secondsJumped = block.timestamp - timestampBeforeJump
+                    assert(secondsJumped >= secondsToJump)
+                    done()
+                })
+            })
+        })
+    })
+
+
 })


### PR DESCRIPTION
I was having difficulty reseting time back to original time for my unit tests after making the `evm_increaseTime` call to change the time. I saw the setTime function wasn't exposed and was so easy to expose that I decided to make a PR before even getting feedback. 