### PR TITLE
accept array of topics to filter events

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -530,8 +530,13 @@ StateManager.prototype.getLogs = function(filter, callback) {
         filtered = filtered.filter(function(log) {
           var keep = true;
           for (var i = 0; i < expectedTopics.length; i++) {
-            if (expectedTopics[i] == null) continue;
-            if (i >= log.topics.length || expectedTopics[i] != log.topics[i]) {
+            var expectedTopic = expectedTopics[i];
+            var logTopic = log.topics[i];
+            if (expectedTopic == null) continue;
+            var isMatch = Array.isArray(expectedTopic)
+              ? expectedTopic.includes(logTopic)
+              : expectedTopic === logTopic;
+            if (i >= log.topics.length || !isMatch) {
               keep = false;
               break;
             }

--- a/test/events.js
+++ b/test/events.js
@@ -81,7 +81,7 @@ var tests = function(web3, EventTest) {
 
     it("handles events properly, using `event.get()`", function(done) {
       this.timeout(10000)
-      var expected_value = 5;
+      var expected_value = 6;
       var interval;
 
       var event = instance.ExampleEvent({first: expected_value});
@@ -92,7 +92,7 @@ var tests = function(web3, EventTest) {
         done(err);
       }
 
-      instance.triggerEvent(5, 7, {from: accounts[0]}, function(err, result) {
+      instance.triggerEvent(6, 7, {from: accounts[0]}, function(err, result) {
         if (err) return cleanup(err);
 
         interval = setInterval(function() {
@@ -115,6 +115,20 @@ var tests = function(web3, EventTest) {
     it("grabs events in the past, using `event.get()`", function(done) {
       var expected_value = 5;
       var event = instance.ExampleEvent({first: expected_value}, {fromBlock: 0});
+
+      event.get(function(err, logs) {
+        event.stopWatching();
+        if (err) return done(err);
+        assert(logs.length == 1);
+        done();
+      });
+    });
+
+    // NOTE! This test relies on the events triggered in the tests above.
+    it("accepts an array of topics as a filter", function(done) {
+      var expected_value_a = 5;
+      var expected_value_b = 6;
+      var event = instance.ExampleEvent({first: [expected_value_a, expected_value_b]}, {fromBlock: 0});
 
       event.get(function(err, logs) {
         event.stopWatching();


### PR DESCRIPTION
Allows the filtering of events by an array of topics.

Issues: https://github.com/ethereumjs/testrpc/issues/311 and https://github.com/ethereumjs/testrpc/issues/322