### PR TITLE
Fixed broken web3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-testrpc",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "bin": {
     "testrpc": "./bin/testrpc"
   },

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "seedrandom": "~2.4.2",
     "shelljs": "~0.6.0",
     "solc": "0.4.6",
-    "web3": "~0.16.0",
-    "web3-provider-engine": "~8.1.0",
+    "web3": "^0.19.1",
+    "web3-provider-engine": "~13.0.0",
     "yargs": "~3.29.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgraded web3 to ^0.19.1 and web3-provider-engine to ~13.0.0 to fix https://github.com/ethereumjs/testrpc/issues/332

Tests still need to be fixed.