### PR TITLE
add the correct entry point for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ADD . .
 
 EXPOSE 8545
 
-ENTRYPOINT ["node", "./bin/testrpc"]
+ENTRYPOINT ["node", "./build/cli.node.js"]


### PR DESCRIPTION
This fixes the current Dockerfile build by specifying the correct path to the testrpc CLI.