### PR TITLE
Fix for #349. Replaced ./bin/testrpc by ./cli.js after file renaming in 464039b32396e6fac406ecc087d9900e7d47268d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ADD . .
 
 EXPOSE 8545
 
-ENTRYPOINT ["node", "./bin/testrpc"]
+ENTRYPOINT ["node", "./cli.js"]


### PR DESCRIPTION
Fix for #349.

testrpc file was renamed in commit: 464039b32396e6fac406ecc087d9900e7d47268d, but Dockerfile wasn't updated.