### PR TITLE
Fix README argv desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Options:
 * `-g` or `--gasPrice`: Use a custom Gas Price (defaults to 20000000000)
 * `-l` or `--gasLimit`: Use a custom Gas Limit (defaults to 0x47E7C4)
 * `-f` or `--fork`: Fork from another currently running Ethereum client at a given block. Input should be the HTTP location and port of the other client, e.g. `http://localhost:8545`. You can optionally specify the block to fork from using an `@` sign: `http://localhost:8545@1599200`.
-* `-i` or `--network-id`: Specify the network id the TestRPC will use to identify itself (defaults to the current time or the network id of the forked blockchain if configured)
+* `-i` or `--networkId`: Specify the network id the TestRPC will use to identify itself (defaults to the current time or the network id of the forked blockchain if configured)
 * `--db`: Specify a path to a directory to save the chain database. If a database already exists, the TestRPC will initialize that chain instead of creating a new one.
 * `--debug`: Output VM opcodes for debugging
 * `--mem`: Output TestRPC memory usage statistics. This replaces normal output.


### PR DESCRIPTION
In the READEME file(42 line):

* `-i` or `--network-id`: Specify the network id the TestRPC will ...

But I found the 76 line of `cli.js` file:
```
network_id: argv.i || argv.networkId,
```

Although `--network-id` still work(yargs parse?), but it's confused. And i think it's better to use `--networkId` and `--networkId` can stay the same with `gasPrice`, `gasLimit` and the later **options desc**.