### PR TITLE
Enable source maps for more easy debugging production errors

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+
+require('source-map-support').install({
+  environment: 'node'
+});
+
 // `yargs/yargs` required to work with webpack, see here.
 // https://github.com/yargs/yargs/issues/781
 var yargs = require('yargs/yargs');

--- a/lib.js
+++ b/lib.js
@@ -1,3 +1,7 @@
+require('source-map-support').install({
+  environment: 'node'
+});
+
 var Provider = require("ganache-core/lib/provider");
 var Server = require("ganache-core/lib/server");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -687,6 +687,17 @@
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        }
       }
     },
     "babel-runtime": {
@@ -6024,12 +6035,18 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
-      "dev": true,
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/ethereumjs/testrpc"
   },
   "dependencies": {
+    "source-map-support": "^0.5.0",
     "webpack": "^3.0.0"
   }
 }

--- a/webpack/cli.webpack.config.js
+++ b/webpack/cli.webpack.config.js
@@ -10,6 +10,7 @@ var outputFilename = 'cli.node.js';
 module.exports = {
   entry: './cli.js',
   target: 'node',
+  devtool: 'source-map',
   output: {
     path: outputDir,
     filename: outputFilename,

--- a/webpack/lib.webpack.config.js
+++ b/webpack/lib.webpack.config.js
@@ -8,6 +8,7 @@ var outputFilename = 'lib.node.js';
 module.exports = {
   entry: './lib.js',
   target: 'node',
+  devtool: 'source-map',
   output: {
     path: outputDir,
     filename: outputFilename,

--- a/webpack/provider.webpack.config.js
+++ b/webpack/provider.webpack.config.js
@@ -8,6 +8,7 @@ var outputFilename = 'provider.node.js';
 module.exports = {
   entry: './node_modules/ganache-core/lib/provider.js',
   target: 'node',
+  devtool: 'source-map',
   output: {
     path: outputDir,
     filename: outputFilename,

--- a/webpack/server.webpack.config.js
+++ b/webpack/server.webpack.config.js
@@ -8,6 +8,7 @@ var outputFilename = 'server.node.js';
 module.exports = {
   entry: './node_modules/ganache-core/lib/server.js',
   target: 'node',
+  devtool: 'source-map',
   output: {
     path: outputDir,
     filename: outputFilename,


### PR DESCRIPTION
An error will now look like:

```
EthereumJS TestRPC v6.0.2 (ganache-core: 2.0.1)
/Users/roderik/Development/testrpc/build/cli.node.js:77882
var Module;if(!Module)Module=(typeof Module!=="undefined"?Module:null)||{};var moduleOverrides={};for(var key in Module){if(Module.hasOwnProperty(key)){moduleOverrides[key]=Module[key]}}var ENVIRONMENT_IS_WEB=false;var ENVIRONMENT_IS_WORKER=false;var ENVIRONMENT_IS_NODE=false;var ENVIRONMENT_IS_SHELL=false;if(Module["ENVIRONMENT"]){if(Module["ENVIRONMENT"]==="WEB"){ENVIRONMENT_IS_WEB=true}else if(Module["ENVIRONMENT"]==="WORKER"){ENVIRONMENT_IS_WORKER=true}else if(Module["ENVIRONMENT"]==="NODE"){ENVIRONMENT_IS_NODE=true}else if(Module["ENVIRONMENT"]==="SHELL"){ENVIRONMENT_IS_SHELL=true}else{throw new Error("The provided Module['ENVIRONMENT'] value is not valid. It must be one of: WEB|WORKER|NODE|SHELL.")}}else{ENVIRONMENT_IS_WEB=typeof window==="object";ENVIRONMENT_IS_WORKER=typeof importScripts==="function";ENVIRONMENT_IS_NODE=typeof process==="object"&&"function"==="function"&&!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_WORKER;ENVIRONMENT_IS_SHELL=!ENVIR

Error: listen EADDRINUSE 0.0.0.0:8545
    at Object._errnoException (util.js:1024:11)
    at _exceptionWithHostPort (util.js:1046:20)
    at Server.setupListenHandle [as _listen2] (net.js:1351:14)
    at listenInCluster (net.js:1392:12)
    at doListen (net.js:1501:7)
    at _combinedTickCallback (internal/process/next_tick.js:141:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
    at Function.Module.runMain (module.js:678:11)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
```

The stacktrace should be readable with this change so it is a lot more easy to figure out where it went wrong