### PR TITLE
fix: All instances of "blocktime" => "blockTime"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Options:
 
 * `-a` or `--accounts`: Specify the number of accounts to generate at startup.
 * `-e` or `--defaultBalanceEther`: Amount of ether to assign each test account. Default is 100.
-* `-b` or `--blocktime`: Specify blocktime in seconds for automatic mining. Default is 0 and no auto-mining.
+* `-b` or `--blockTime`: Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
 * `-d` or `--deterministic`: Generate deterministic addresses based on a pre-defined mnemonic.
 * `-n` or `--secure`: Lock available accounts by default (good for third party transaction signing)
 * `-m` or `--mnemonic`: Use a specific HD wallet mnemonic to generate initial addresses.

--- a/cli.js
+++ b/cli.js
@@ -50,7 +50,7 @@ if (argv.help || argv['?']) {
   console.log("");
   console.log("  --noVMErrorsOnRPCResponse   (Do not transmit transaction failures as RPC errors. Enable this flag for error reporting behaviour which is compatible with other clients such as geth and Parity.)");
   console.log("");
-  console.log("  --blocktime/-b <block time in seconds> (Will instamine if option omitted. Avoid using unless your test cases require interval mining.)");
+  console.log("  --blockTime/-b <block time in seconds> (Will instamine if option omitted. Avoid using unless your test cases require interval mining.)");
   console.log("  --networkId/-i <network id> (default current time)");
   console.log("  --gasPrice/-g <gas price>   (default 20000000000)");
   console.log("  --gasLimit/-l <gas limit>   (default 90000)");
@@ -116,7 +116,7 @@ var options = {
   mnemonic: argv.m || argv.mnemonic,
   total_accounts: argv.a || argv.accounts,
   default_balance_ether: argv.e || argv.defaultBalanceEther,
-  blocktime: argv.b || argv.blocktime,
+  blockTime: argv.b || argv.blockTime,
   gasPrice: argv.g || argv.gasPrice,
   gasLimit: argv.l || argv.gasLimit,
   accounts: parseAccounts(argv.account),


### PR DESCRIPTION
The documentation points to using the `--blocktime` flag, but it caused ganache to crash. It works as expected when I changed it to `--blockTime`, so wanted to update the docs accordingly.