### PR TITLE
FIX #490: --help flag does not output the full list of options

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,8 @@ var parser = yargs()
 .option("unlock", {
   type: "string",
   alias: "u"
-});
+})
+.help(false);
 
 var argv = parser.parse(process.argv);
 


### PR DESCRIPTION
This PR solves an issue about output when `--help` flag is specified.

Unless we specify `.help(false)` for yargs, an implicit command displays the usage string and exits the process. See https://github.com/yargs/yargs/blob/ead118aac46fdeb9087bfba22d4ee6623ba886c5/docs/api.md#help

## Current behavior

```
$ LANG=C node cli.js --help
Options:
  --help        Show help                                              [boolean]
  --version     Show version number                                    [boolean]
  --unlock, -u                                                          [string]
```

## Behavior after applying this PR

```
$ LANG=C node cli.js --help

ganache-cli: Fast Ethereum RPC client for testing and development
  Full docs: https://github.com/trufflesuite/ganache-cli

Usage: ganache-cli [options]
  options:
  --port/-p <port to bind to, default 8545>
  --host/-h <host to bind to, default 127.0.0.1>
  --fork/-f <url>   (Fork from another currently running Ethereum client at a given block)

  --db <db path>   (directory to save chain db)
  --seed/-s <seed value for PRNG, default random>
  --deterministic/-d     (uses fixed seed)
  --mnemonic/-m <mnemonic>

  --accounts/-a <number of accounts to generate at startup>   (ignored when using --account flag)
  --defaultBalanceEther/-e <Amount of ether to assign each test account, default 100.0>   (ignored when using --account flag)
  --account <privatekey>,<balance>   (Can be specified multiple times. Note that private keys are 64 characters long,
                                       and must be input as a 0x-prefixed hex string. Balance can either be input as an
                                       integer or 0x-prefixed hex value specifying the amount of wei in that account.)

  --acctKeys <path to file>   (saves generated accounts and private keys as JSON object in specified file)
  --secure/-n   (Lock accounts by default)
  --unlock <accounts>   (Comma-separated list of accounts or indices to unlock)

  --noVMErrorsOnRPCResponse   (Do not transmit transaction failures as RPC errors. Enable this flag for error reporting behaviour which is compatible with other clients such as geth and Parity.)

  --blockTime/-b <block time in seconds> (Will instamine if option omitted. Avoid using unless your test cases require interval mining.)
  --networkId/-i <network id> (default current time)
  --gasPrice/-g <gas price>   (default 20000000000)
  --gasLimit/-l <gas limit>   (default 90000)

  --debug       (Output VM opcodes for debugging)
  --verbose/-v
  --mem         (Only show memory output, not tx history)


  --help / -?    (this output)
```