### PR TITLE
Update the blockTime option description

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Options:
 
 * `-a` or `--accounts`: Specify the number of accounts to generate at startup.
 * `-e` or `--defaultBalanceEther`: Amount of ether to assign each test account. Default is 100.
-* `-b` or `--blockTime`: Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
+* `-b` or `--blockTime`: Specify blockTime in seconds for automatic mining. If you don't specify this flag, ganache will instantly mine a new block for every transaction. Using the --blockTime flag is discouraged unless you have tests which require a specific mining interval.
 * `-d` or `--deterministic`: Generate deterministic addresses based on a pre-defined mnemonic.
 * `-n` or `--secure`: Lock available accounts by default (good for third party transaction signing)
 * `-m` or `--mnemonic`: Use a specific HD wallet mnemonic to generate initial addresses.


### PR DESCRIPTION
I expanded and correct the current description which is currently ambiguous (why does 0 seconds mean? If each transaction is mined in 0 seconds (instantaneously), why then the documentation states `no auto-mining.`)

I took part of the description from  https://github.com/trufflesuite/ganache-cli/pull/483#issuecomment-367553231