### PR TITLE
By default accept requests from localhost only

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options:
 * `-n` or `--secure`: Lock available accounts by default (good for third party transaction signing)
 * `-m` or `--mnemonic`: Use a specific HD wallet mnemonic to generate initial addresses.
 * `-p` or `--port`: Port number to listen on. Defaults to 8545.
-* `-h` or `--hostname`: Hostname to listen on. Defaults to Node's `server.listen()` [default](https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback).
+* `-h` or `--hostname`: Hostname to listen on. Defaults to 127.0.0.1.
 * `-s` or `--seed`: Use arbitrary data to generate the HD wallet mnemonic to be used.
 * `-g` or `--gasPrice`: Use a custom Gas Price (defaults to 20000000000)
 * `-l` or `--gasLimit`: Use a custom Gas Limit (defaults to 90000)

--- a/cli.js
+++ b/cli.js
@@ -61,7 +61,7 @@ if (argv.mem === true) {
 
 var options = {
   port: argv.p || argv.port || "8545",
-  hostname: argv.h || argv.hostname || "localhost",
+  hostname: argv.h || argv.hostname || "127.0.0.1",
   debug: argv.debug,
   seed: argv.s || argv.seed,
   mnemonic: argv.m || argv.mnemonic,

--- a/cli.js
+++ b/cli.js
@@ -61,7 +61,7 @@ if (argv.mem === true) {
 
 var options = {
   port: argv.p || argv.port || "8545",
-  hostname: argv.h || argv.hostname,
+  hostname: argv.h || argv.hostname || "localhost",
   debug: argv.debug,
   seed: argv.s || argv.seed,
   mnemonic: argv.m || argv.mnemonic,
@@ -186,7 +186,7 @@ server.listen(options.port, options.hostname, function(err, result) {
   }
 
   console.log("");
-  console.log("Listening on " + (options.hostname || "localhost") + ":" + options.port);
+  console.log("Listening on " + options.hostname + ":" + options.port);
 });
 
 process.on('uncaughtException', function(e) {


### PR DESCRIPTION
The default behavior of nodejs http server when not specifying hostname
is listen to 0.0.0.0 for IPv4 or :: for IPv6, which means accept
connections on all IP address.  This patch specifes the hostname to
localhost when the hostname was not specified in command line argument
(-h and --hostname), because:

* Let RPC port opening to world is a bad idea.
* The default behavier of geth is listening to localhost only.
* I believe it is the original intention, see the message from L189.