### PR TITLE
Update Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.7
-      - g++-4.7
+      - gcc-5
+      - g++-5
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CC="gcc-4.7";
-      export CXX="g++-4.7";
-      export LINK="gcc-4.7";
-      export LINKXX="g++-4.7";
+      export CC="gcc-5";
+      export CXX="g++-5";
+      export LINK="gcc-5";
+      export LINKXX="g++-5";
     fi
   - nvm --version
   - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "node"
-  - "lts/boron"
+  - "lts/carbon"
 
 addons:
   apt:


### PR DESCRIPTION
This updates the Travis CI to be GCC v5 and the LTS build is Carbon (instead of Boron) to match https://github.com/trufflesuite/ganache-core