### PR TITLE
Fix broken --host option due to being overridden by help option

### DIFF
--- a/args.js
+++ b/args.js
@@ -138,8 +138,8 @@ module.exports = exports = function(yargs, version) {
       type: 'boolean',
       default: false
     })
-    .showHelpOnFail(false, 'Specify -h, -?, or --help for available options') 
-    .help('h')
-    .alias('h', ['?', 'help'])
+    .showHelpOnFail(false, 'Specify -? or --help for available options')
+    .help('help')
+    .alias('help', '?')
     .version(version)
 }


### PR DESCRIPTION
The help option was defined to use the 'h' shorthand option.
However, this was overriding the previous host option which also used the 'h' shorthand option.
Thus running ganache-cli with the '-h' or even '--host' option did not work and showed the help output.
Now only the '--help' and '-?' options trigger the help output which is the expected behaviour.

I'd be happy if you could do a minor release if this is fixed/merged as now any setup that uses the host option is broken... other than that, great work on the very helpful ganache-cli tool!