### PR TITLE
Fix faulty `--hostname` CLI option

### DIFF
--- a/args.js
+++ b/args.js
@@ -9,7 +9,7 @@ module.exports = exports = function(yargs, version) {
     })
     .option('h', {
       group: 'Network:',
-      alias: 'host',
+      alias: ['host', 'hostname'],
       default: '127.0.0.1',
       describe: 'host to bind to'
     })

--- a/cli.js
+++ b/cli.js
@@ -61,7 +61,7 @@ if (argv.mem === true) {
 
 var options = {
   port: argv.p || argv.port || "8545",
-  hostname: argv.h || argv.hostname || "127.0.0.1",
+  hostname: argv.h,
   debug: argv.debug,
   seed: argv.s || argv.seed,
   mnemonic: argv.m || argv.mnemonic,


### PR DESCRIPTION
Since the _-h_ option was fixed, `argv.h` is mostly truthy, it either has the value passed through CLI or the default value _127.0.0.1_.
Thus `|| argv.hostname || "127.0.0.1"` is dead code and _--hostname_ option cannot be used to set the hostname anymore.

Removed dead code, use the default value set in yargs.
Added _--hostname_ option in yargs.