### PR TITLE
Add flag for unlimited contract size

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Options:
 * `--debug`: Output VM opcodes for debugging
 * `--mem`: Output ganache-cli memory usage statistics. This replaces normal output.
 * `--noVMErrorsOnRPCResponse`: Do not transmit transaction failures as RPC errors. Enable this flag for error reporting behaviour which is compatible with other clients such as geth and Parity.
+* `--allowUnlimitedContractSize`: Allows unlimited contract sizes while debugging. By enabling this flag, the check within the EVM for contract size limit of 2KB (see EIP-170) is bypassed. Enabling this flag **will** cause ganache-cli to behave differently than production environments.
 
 Special Options:
 
@@ -114,6 +115,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"db_path"`: `String` - Specify a path to a directory to save the chain database. If a database already exists, `ganache-cli` will initialize that chain instead of creating a new one.
 * `"account_keys_path"`: `String` - Specifies a file to save accounts and private keys to, for testing.
 * `"vmErrorsOnRPCResponse"`: `boolean` - Whether or not to transmit transaction failures as RPC errors. Set to `false` for error reporting behaviour which is compatible with other clients such as geth and Parity.
+* `"allowUnlimitedContractSize"`: `boolean` - Allows unlimited contract sizes while debugging. By setting this to `true`, the check within the EVM for contract size limit of 2KB (see [EIP-170](https://git.io/vxZkK)) is bypassed. Setting this to true **will** cause ganache-core to behave differently than production environments. (default: `false`; **ONLY** set to `true` during debugging).
 
 ### Implemented Methods
 

--- a/args.js
+++ b/args.js
@@ -120,6 +120,12 @@ module.exports = exports = function(yargs, version) {
       type: 'number',
       default: 0x6691b7
     })
+    .option('allowUnlimitedContractSize', {
+      group: 'Chain:',
+      describe: 'Allows unlimited contract sizes while debugging. By enabling this flag, the check within the EVM for contract size limit of 2KB (see EIP-170) is bypassed. Enabling this flag *will* cause ganache-cli to behave differently than production environments.',
+      type: 'boolean',
+      default: false
+    })
     .option('debug', {
       group: 'Other:',
       describe: 'Output VM opcodes for debugging',

--- a/cli.js
+++ b/cli.js
@@ -79,7 +79,8 @@ var options = {
   db_path: argv.db || null,
   account_keys_path: argv.acctKeys || null,
   vmErrorsOnRPCResponse: !argv.noVMErrorsOnRPCResponse,
-  logger: logger
+  logger: logger,
+  allowUnlimitedContractSize: argv.allowUnlimitedContractSize || false
 }
 
 var fork_address;


### PR DESCRIPTION
This PR adds the flag for `allowUnlimitedContractSize` which was added to `ganache-core` in https://github.com/trufflesuite/ganache-core/pull/126