### PR TITLE
Default host of 0.0.0.0 fixes #556

### DIFF
--- a/args.js
+++ b/args.js
@@ -11,7 +11,7 @@ module.exports = exports = function(yargs, version) {
       group: 'Network:',
       alias: ['host', 'hostname'],
       type: 'string',
-      default: '127.0.0.1',
+      default: '0.0.0.0',
       describe: 'Hostname to listen on'
     })
     .option('a', {


### PR DESCRIPTION
This change should remove the need to specify the hostname to listen on 0.0.0.0 in order to allow connections from outside a docker network.  See Issue #556 for more information.