### PR TITLE
Remove 'wei' units from block gas limit parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Options:
 * `-h` or `--host` or `--hostname`: Hostname to listen on. Defaults to 127.0.0.1 (defaults to 0.0.0.0 for Docker instances of ganache-cli).
 * `-s` or `--seed`: Use arbitrary data to generate the HD wallet mnemonic to be used.
 * `-g` or `--gasPrice`: The price of gas in wei (defaults to 20000000000)
-* `-l` or `--gasLimit`: The block gas limit in wei (defaults to 0x6691b7)
+* `-l` or `--gasLimit`: The block gas limit (defaults to 0x6691b7)
 * `-f` or `--fork`: Fork from another currently running Ethereum client at a given block. Input should be the HTTP location and port of the other client, e.g. `http://localhost:8545`. You can optionally specify the block to fork from using an `@` sign: `http://localhost:8545@1599200`.
 * `-i` or `--networkId`: Specify the network id ganache-cli will use to identify itself (defaults to the current time or the network id of the forked blockchain if configured)
 * `--db`: Specify a path to a directory to save the chain database. If a database already exists, ganache-cli will initialize that chain instead of creating a new one.


### PR DESCRIPTION
As I understand it, the block gas limit, `gasLimit` is in terms of the maximum EVM gas used, as opposed to the amount of Ether spent for each gas unit.    At present, the `-l` /`gasLimit` parameter is noted as being in units of Wei. The suggested minor update removes the units to avoid confusion for new users.  Thanks to the devs and maintainers for this useful project.