### PR TITLE
Use Docker multistage builds for reduced imagesize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:8
+FROM mhart/alpine-node:8 as builder
 
 RUN apk add --no-cache make gcc g++ python git bash
 COPY package.json /src/package.json
@@ -8,8 +8,14 @@ RUN npm install
 ADD . .
 RUN npm run build
 
+FROM mhart/alpine-node:8 as runtime
+
+WORKDIR /app
+COPY --from=builder "/src/build/cli.node.js" "./cli.node.js"
+COPY --from=builder "/src/build/cli.node.js.map" "./cli.node.js.map"
+
 ENV DOCKER true
 
 EXPOSE 8545
 
-ENTRYPOINT ["node", "./build/cli.node.js"]
+ENTRYPOINT ["node", "/app/cli.node.js"]


### PR DESCRIPTION
This drastically reduces the size of the resulting docker image.

The image with the `multi-stage-build` tag is the new one (73MB uncompressed) whereas the other ones are downloaded from DockerHub (573MB).

![image](https://user-images.githubusercontent.com/5486389/44140587-d7bc8b24-a0bd-11e8-9007-d03d16cf771d.png)

Is there a way how I can run tests against the new image to see if it still works correctly?
I did a manual smoke test and it seems to be working fine!