### PR TITLE
Allow silencing output

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Options:
 * `--db`: Specify a path to a directory to save the chain database. If a database already exists, ganache-cli will initialize that chain instead of creating a new one.
 * `--debug`: Output VM opcodes for debugging
 * `--mem`: Output ganache-cli memory usage statistics. This replaces normal output.
+* `-q` or `--quiet`: Run ganache-cli without any logs.
 * `-v` or `--verbose`: Log all requests and responses to stdout
 * `-?` or `--help`: Display help information
 * `--version`: Display the version of ganache-cli

--- a/args.js
+++ b/args.js
@@ -158,6 +158,13 @@ module.exports = exports = function(yargs, version, isDocker) {
       type: 'boolean',
       default: false
     })
+    .option('q', {
+      group: 'Other:',
+      alias: 'quiet',
+      describe: 'Run ganache quietly (no logs)',
+      type: 'boolean',
+      default: false
+    })
     .showHelpOnFail(false, 'Specify -? or --help for available options')
     .help('help')
     .alias('help', '?')

--- a/cli.js
+++ b/cli.js
@@ -51,6 +51,13 @@ if (typeof argv.unlock == "string") {
 
 var logger = console;
 
+// If quiet argument passed, no output
+if (argv.q === true){
+  logger = {
+    log: function() {}
+  };
+}
+
 // If the mem argument is passed, only show memory output,
 // not transaction history.
 if (argv.mem === true) {


### PR DESCRIPTION
When running a large volume of tests/transactions against the local ganache-cli EVM (especially when using a custom config with a large amount of account Ether balance), it would be nice to be able to silence any log output in order to increase performance.

## Steps to Test

In one terminal window:
`ganache-cli -q` or `ganache-cli --quiet`

In another terminal window:
`cd myTruffleProjectWithTests`
`truffle test`

## Expected Outcome

Truffle tests run and ganache-cli doesn't output anything after the initial start and below the following line:
`Listening on 127.0.0.1:8545`