### PR TITLE
Add flag for setting first block start time

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
 * `--noVMErrorsOnRPCResponse`: Do not transmit transaction failures as RPC errors. Enable this flag for error reporting behaviour which is compatible with other clients such as geth and Parity.
 * `--allowUnlimitedContractSize`: Allows unlimited contract sizes while debugging. By enabling this flag, the check within the EVM for contract size limit of 24KB (see EIP-170) is bypassed. Enabling this flag **will** cause ganache-cli to behave differently than production environments.
 * `--keepAliveTimeout`: Sets the HTTP server's `keepAliveTimeout` in milliseconds. See the [NodeJS HTTP docs](https://nodejs.org/api/http.html#http_server_keepalivetimeout) for details. `5000` by default.
+* `-t` or `--time`: Date (ISO 8601) that the first block should start. Use this feature, along with the evm_increaseTime method to test time-dependent code.
 
 Special Options:
 

--- a/args.js
+++ b/args.js
@@ -139,6 +139,19 @@ module.exports = exports = function(yargs, version, isDocker) {
       type: 'boolean',
       default: false
     })
+    .option('t', {
+      group: 'Chain:',
+      alias: 'time',
+      describe: 'Date (ISO 8601) that the first block should start. Use this feature, along with the evm_increaseTime method to test time-dependent code.',
+      type: 'string',
+      coerce: (arg) => {
+        let timestamp = Date.parse(arg);
+        if (isNaN(timestamp)) {
+          throw new Error('Invalid \'time\' format');
+        }
+        return new Date(timestamp);
+      }
+    })
     .option('debug', {
       group: 'Other:',
       describe: 'Output VM opcodes for debugging',

--- a/cli.js
+++ b/cli.js
@@ -91,7 +91,8 @@ var options = {
   account_keys_path: argv.acctKeys,
   vmErrorsOnRPCResponse: !argv.noVMErrorsOnRPCResponse,
   logger: logger,
-  allowUnlimitedContractSize: argv.allowUnlimitedContractSize
+  allowUnlimitedContractSize: argv.allowUnlimitedContractSize,
+  time: argv.t
 }
 
 var fork_address;


### PR DESCRIPTION
Add `-t` (`--time`) flag for setting first block start time using date in ISO 8601 format.

Fixes: #580