### PR TITLE
Add Option for HTTP Server keepAliveTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options:
 * `--version`: Display the version of ganache-cli
 * `--noVMErrorsOnRPCResponse`: Do not transmit transaction failures as RPC errors. Enable this flag for error reporting behaviour which is compatible with other clients such as geth and Parity.
 * `--allowUnlimitedContractSize`: Allows unlimited contract sizes while debugging. By enabling this flag, the check within the EVM for contract size limit of 24KB (see EIP-170) is bypassed. Enabling this flag **will** cause ganache-cli to behave differently than production environments.
+* `-t` or `--keepAliveTimeout`: Sets the HTTP server's `keepAliveTimeout` in milliseconds. See the [NodeJS HTTP docs](https://bit.ly/2Cr0ZEh) for details. `5000` by default.
 
 Special Options:
 
@@ -122,6 +123,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"account_keys_path"`: `String` - Specifies a file to save accounts and private keys to, for testing.
 * `"vmErrorsOnRPCResponse"`: `boolean` - Whether or not to transmit transaction failures as RPC errors. Set to `false` for error reporting behaviour which is compatible with other clients such as geth and Parity.
 * `"allowUnlimitedContractSize"`: `boolean` - Allows unlimited contract sizes while debugging. By setting this to `true`, the check within the EVM for contract size limit of 24KB (see [EIP-170](https://git.io/vxZkK)) is bypassed. Setting this to true **will** cause ganache-core to behave differently than production environments. (default: `false`; **ONLY** set to `true` during debugging).
+* `"keepAliveTimeout"`: Sets the HTTP server's `keepAliveTimeout` in milliseconds. See the [NodeJS HTTP docs](https://bit.ly/2Cr0ZEh) for details. `5000` by default.
 
 ### Implemented Methods
 

--- a/args.js
+++ b/args.js
@@ -15,6 +15,13 @@ module.exports = exports = function(yargs, version, isDocker) {
       default: isDocker ? '0.0.0.0' : '127.0.0.1',
       describe: 'Hostname to listen on'
     })
+    .option('t', {
+      group: 'Network:',
+      alias: 'keepAliveTimeout',
+      type: 'number',
+      default: 5000,
+      describe: 'The number of milliseconds of inactivity a server needs to wait for additional incoming data, after it has finished writing the last response, before a socket will be destroyed.'
+    })
     .option('a', {
       group: 'Accounts:',
       alias: 'accounts',

--- a/cli.js
+++ b/cli.js
@@ -91,7 +91,8 @@ var options = {
   account_keys_path: argv.acctKeys,
   vmErrorsOnRPCResponse: !argv.noVMErrorsOnRPCResponse,
   logger: logger,
-  allowUnlimitedContractSize: argv.allowUnlimitedContractSize
+  allowUnlimitedContractSize: argv.allowUnlimitedContractSize,
+  keepAliveTimeout: argv.t
 }
 
 var fork_address;


### PR DESCRIPTION
This PR adds an option `keepAliveTimeout`. This option, defaulted to `5000`, specifies the number of milliseconds the server should wait before moving on. The primary use case is to help me debug other tools that use ganache; I get timeouts while I step through code. See https://nodejs.org/api/http.html#http_server_keepalivetimeout for more details

See the associated `ganache-core` PR here: https://github.com/trufflesuite/ganache-core/pull/199