### PR TITLE
Allows environment variables to be used as args

### DIFF
--- a/args.js
+++ b/args.js
@@ -1,6 +1,7 @@
 module.exports = exports = function(yargs, version, isDocker) {
   return yargs
     .strict()
+    .env('GANACHE_CLI')
     .option('p', {
       group: 'Network:',
       alias: 'port',


### PR DESCRIPTION
Utilizes this yargs feature (http://yargs.js.org/docs/#api-envprefix) to allow all command line arguments to be allowed to be specified via environment variables prefixed with `GANACHE_CLI` (can easily be changed).

For example, these two commands are equivalent
```javascript
ganache-cli --mnemonic sample_mnemonic

GANACHE_CLI_MNEMONIC=sample_mnemonic ganache-cli
```

The motivation for this feature spawned from my use case: I run ganache-cli's docker image as a secondary image in CircleCI so I can automate my tests. CircleCI doesn't let me use environment variables when I use the docker entrypoint command args (`docker run ganache-cli --mnemonic $MNEMONIC` doesn't work). However I am allowed to specify a dictionary of environment variables where I hope environment variables are properly interpolated.
