### PR TITLE
Resolve ganache-core from the consumer app instead of relative path

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,7 +8,7 @@ require('source-map-support/register')
 var yargs = require('yargs');
 var Ganache = require("ganache-core");
 var pkg = require("./package.json");
-var corepkg = require("./node_modules/ganache-core/package.json");
+var corepkg = require("ganache-core/package.json");
 var URL = require("url");
 var fs = require("fs");
 var to = require("ganache-core/lib/utils/to");


### PR DESCRIPTION
We had encountered the following error:

```
$ yarn devchain
yarn run v1.12.3
$ ganache-cli --gasLimit 0x7a1200 --defaultBalanceEther 10000000000000
Error: Cannot find module './node_modules/ganache-core/package.json'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/schmidsi/Development/@melonproject/protocol/node_modules/ganache-cli/cli.js:11:15)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:266:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Our setup is, that we do not install ganache-cli globally, but have it as a dependency. Then, we start it with: `yarn ganache-cli` which looks in `node_modules/.bin/ganache-cli` which resolves to `node_modules/ganache-cli/cli.js`. But `node_modules/ganache-cli` does not contain a folder `node_modules`

This was our commit where it errors:
https://github.com/melonproject/protocol/tree/08f0e66be8724f921bf2f82bf785f034faf75818

This commit fixes the problem.