### PR TITLE
Clarify evm_snapshot behavior in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The RPC methods currently implemented are:
 
 There’s also special non-standard methods that aren’t included within the original RPC specification:
 
-* `evm_snapshot` : Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the integer id of the snapshot created.
+* `evm_snapshot` : Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the integer id of the snapshot created. A snapshot can only be used once. After a succesful revert, the same snapshot id cannot be used again. Consider creating a new snapshot after your reverts if you need to revert to the same point several times.
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.
 * `evm_increaseTime` : Jump forward in time. Takes one parameter, which is the amount of time to increase in seconds. Returns the total time adjustment, in seconds.
 * `evm_mine` : Force a block to be mined. Takes one optional parameter, which is the timestamp a block should setup as the mining time. Mines a block independent of whether or not mining is started or stopped.


### PR DESCRIPTION
Improve the description of evm_snapshot as I couldn't find any documentation mentioning the fact that snapshot ids can only be used once.

Done on ganache-core too => https://github.com/trufflesuite/ganache-core/pull/284