### PR TITLE
Add hd_path to cli

### DIFF
--- a/args.js
+++ b/args.js
@@ -97,8 +97,9 @@ module.exports = exports = function(yargs, version, isDocker) {
       demandOption: false
     })
     .option('hdPath', {
-        group: 'Chain:',
-        describe: 'The base path used to derive the accounts from.',
+        group: 'Accounts:',
+        alias: 'hd_path',
+        describe: `The hierarchical deterministic path to use when generating accounts. Default: "m/44'/60'/0'/0/"`,
         type: 'string',
         demandOption: false
     })

--- a/args.js
+++ b/args.js
@@ -96,6 +96,12 @@ module.exports = exports = function(yargs, version, isDocker) {
       conflicts: 'd',
       demandOption: false
     })
+    .option('hdPath', {
+        group: 'Chain:',
+        describe: 'The base path used to derive the accounts from.',
+        type: 'string',
+        demandOption: false
+    })
     .option('d', {
       group: 'Chain:',
       alias: 'deterministic',

--- a/cli.js
+++ b/cli.js
@@ -92,6 +92,7 @@ var options = {
   verbose: argv.v,
   secure: argv.n,
   db_path: argv.db,
+  hd_path: argv.hdPath,
   account_keys_path: argv.account_keys_path,
   vmErrorsOnRPCResponse: !argv.noVMErrorsOnRPCResponse,
   logger: logger,


### PR DESCRIPTION
This adds the ability to change the base path used to derive from an HD wallet.

This pr pairs with [a pr](https://github.com/trufflesuite/ganache-core/pull/519) in ganache-core.