### PR TITLE
fix: Handle SIGINT, SIGTERM, & SIGHUP gracefully

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -205,6 +205,9 @@ if (process.platform === "win32") {
   })
   .on("SIGINT", function () {
     process.emit("SIGINT");
+  })
+  .on("SIGHUP", function () {
+    process.emit("SIGHUP");
   });
 }
 
@@ -227,3 +230,4 @@ const closeHandler = function () {
 
 process.on("SIGINT", closeHandler);
 process.on("SIGTERM", closeHandler);
+process.on("SIGHUP", closeHandler);

--- a/cli.js
+++ b/cli.js
@@ -205,9 +205,6 @@ if (process.platform === "win32") {
   })
   .on("SIGINT", function () {
     process.emit("SIGINT");
-  })
-  .on("SIGHUP", function () {
-    process.emit("SIGHUP");
   });
 }
 

--- a/cli.js
+++ b/cli.js
@@ -208,7 +208,7 @@ if (process.platform === "win32") {
   });
 }
 
-process.on("SIGINT", function () {
+const closeHandler = function () {
   // graceful shutdown
   server.close(function(err) {
     if (err) {
@@ -216,4 +216,7 @@ process.on("SIGINT", function () {
     }
     process.exit();
   });
-});
+}
+
+process.on("SIGINT", closeHandler);
+process.on("SIGTERM", closeHandler);

--- a/cli.js
+++ b/cli.js
@@ -216,10 +216,12 @@ const closeHandler = function () {
       // writes to process.stdout in Node.js are sometimes asynchronous and may occur over
       // multiple ticks of the Node.js event loop. Calling process.exit(), however, forces
       // the process to exit before those additional writes to stdout can be performed.
-      process.stdout?._handle.setBlocking(true);
+      if(process.stdout._handle) process.stdout._handle.setBlocking(true);
       console.log(err.stack || err);
+      process.exit();
+    } else {
+      process.exit(0);
     }
-    process.exit(0);
   });
 }
 

--- a/cli.js
+++ b/cli.js
@@ -212,9 +212,14 @@ const closeHandler = function () {
   // graceful shutdown
   server.close(function(err) {
     if (err) {
+      // https://nodejs.org/api/process.html#process_process_exit_code
+      // writes to process.stdout in Node.js are sometimes asynchronous and may occur over
+      // multiple ticks of the Node.js event loop. Calling process.exit(), however, forces
+      // the process to exit before those additional writes to stdout can be performed.
+      process.stdout?._handle.setBlocking(true);
       console.log(err.stack || err);
     }
-    process.exit();
+    process.exit(0);
   });
 }
 


### PR DESCRIPTION
Only exit with code 0 when gracefully exiting.


Fixes #738