### PR TITLE
Coffee Cake ☕

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,4 +17,5 @@ jobs:
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
-      run: npx semantic-release
+        NPM_OTP_KEY: ${{ secrets.NPM_OTP_KEY }}
+      run: export NPM_CONFIG_OTP=$(node scripts/release.js) && npx semantic-release

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,20 @@
+name: ganache-cli CD
+
+on:
+  push:
+    branches: [ master, beta ]
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10'
+    - run: npm ci
+    - name: Release
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+      run: npx semantic-release

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,4 +18,4 @@ jobs:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
         NPM_OTP_KEY: ${{ secrets.NPM_OTP_KEY }}
-      run: export NPM_CONFIG_OTP=$(node scripts/release.js) && npx semantic-release
+      run: npx semantic-release

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,10 +12,16 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '10'
-    - run: npm ci
+
+    - name: Install
+      run: npm ci
+
+    - name: Build
+      run: npm run build
+
     - name: Release
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
         NPM_OTP_KEY: ${{ secrets.NPM_OTP_KEY }}
-      run: npx semantic-release
+      run: npm run otp && npx semantic-release

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ FROM mhart/alpine-node:10 as runtime
 WORKDIR /app
 
 COPY --from=builder "/app/node_modules/scrypt/build/Release" "./node_modules/scrypt/build/Release/"
-COPY --from=builder "/app/node_modules/ganache-core/node_modules/scrypt/build/Release" "./node_modules/ganache-core/node_modules/scrypt/build/Release/"
 COPY --from=builder "/app/node_modules/ganache-core/node_modules/secp256k1/build/Release" "./node_modules/ganache-core/node_modules/secp256k1/build/Release/"
 COPY --from=builder "/app/node_modules/ganache-core/node_modules/keccak/build/Release" "./node_modules/ganache-core/node_modules/keccak/build/Release/"
 COPY --from=builder "/app/node_modules/sha3/build/Release" "./node_modules/sha3/build/Release/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ FROM mhart/alpine-node:10 as runtime
 WORKDIR /app
 
 COPY --from=builder "/app/node_modules/scrypt/build/Release" "./node_modules/scrypt/build/Release/"
-COPY --from=builder "/app/node_modules/ganache-core/node_modules/secp256k1/build/Release" "./node_modules/ganache-core/node_modules/secp256k1/build/Release/"
-COPY --from=builder "/app/node_modules/ganache-core/node_modules/keccak/build/Release" "./node_modules/ganache-core/node_modules/keccak/build/Release/"
 COPY --from=builder "/app/node_modules/sha3/build/Release" "./node_modules/sha3/build/Release/"
 COPY --from=builder "/app/node_modules/ganache-core/node_modules/websocket/build/Release" "./node_modules/ganache-core/node_modules/websocket/build/Release/"
 COPY --from=builder "/app/build/ganache-core.docker.cli.js" "./ganache-core.docker.cli.js"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ ganache-cli <options>
 * `--allowUnlimitedContractSize`: Allows unlimited contract sizes while debugging. By enabling this flag, the check within the EVM for contract size limit of 24KB (see EIP-170) is bypassed. Enabling this flag **will** cause ganache-cli to behave differently than production environments.
 * `--keepAliveTimeout`: Sets the HTTP server's `keepAliveTimeout` in milliseconds. See the [NodeJS HTTP docs](https://nodejs.org/api/http.html#http_server_keepalivetimeout) for details. `5000` by default.
 * `-t` or `--time`: Date (ISO 8601) that the first block should start. Use this feature, along with the evm_increaseTime method to test time-dependent code.
+* `--deasync`:  `boolean` Synchronizes ganache server startup. Useful in certain scenarios - see ganache-cli issue [#733](https://github.com/trufflesuite/ganache-cli/issues/733).
 
 Special Options:
 
@@ -168,7 +169,6 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"gasLimit"`: `String::hex | number` Sets the block gas limit. Must be specified as a `hex` string or `number`. Defaults to `"0x6691b7"`.
 * `"callGasLimit"`: `number` Sets the transaction gas limit for `eth_call` and `eth_estimateGas` calls. Must be specified as a `hex` string. Defaults to `"0x1fffffffffffff"` (`Number.MAX_SAFE_INTEGER`).
 * `"keepAliveTimeout"`:  `number` If using `.server()` - Sets the HTTP server's `keepAliveTimeout` in milliseconds. See the [NodeJS HTTP docs](https://nodejs.org/api/http.html#http_server_keepalivetimeout) for details. `5000` by default.
-* `"deasync"`:  `boolean` Synchronizes ganache server startup. Useful in certain scenarios - see ganache-cli issue [#733](https://github.com/trufflesuite/ganache-cli/issues/733).
 
 ## Implemented Methods
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ $ ganache-cli <options>
 * `--allowUnlimitedContractSize`: Allows unlimited contract sizes while debugging. By enabling this flag, the check within the EVM for contract size limit of 24KB (see EIP-170) is bypassed. Enabling this flag **will** cause ganache-cli to behave differently than production environments.
 * `--keepAliveTimeout`: Sets the HTTP server's `keepAliveTimeout` in milliseconds. See the [NodeJS HTTP docs](https://nodejs.org/api/http.html#http_server_keepalivetimeout) for details. `5000` by default.
 * `-t` or `--time`: Date (ISO 8601) that the first block should start. Use this feature, along with the evm_increaseTime method to test time-dependent code.
-* `--deasync`:  `boolean` Synchronizes ganache server startup. Useful in certain scenarios - see ganache-cli issue [#733](https://github.com/trufflesuite/ganache-cli/issues/733).
 
 Special Options:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ $ ganache-cli <options>
 * `--callGasLimit`: Sets the transaction gas limit for `eth_call` and `eth_estimateGas` calls. Must be specified as a `hex` string. Defaults to `"0x1fffffffffffff"` (`Number.MAX_SAFE_INTEGER`)
 * `-k` or `--hardfork`: Allows users to specify which hardfork should be used. Supported hardforks are `byzantium`, `constantinople`, `petersburg`, `istanbul`, and `muirGlacier` (default).
 * `-f` or `--fork`: Fork from another currently running Ethereum client at a given block. Input should be the HTTP location and port of the other client, e.g. `http://localhost:8545`. You can optionally specify the block to fork from using an `@` sign: `http://localhost:8545@1599200`.
+* `forkCacheSize`: `number` - The maximum size, in bytes, of the in-memory cache for queries on a chain fork. Defaults to `1_073_741_824` bytes (1 gigabyte). You can set this to `0` to disable caching (not recommended), or to `-1` for unlimited (will be limited by your node process).
 * `-i` or `--networkId`: Specify the network id ganache-cli will use to identify itself (defaults to the current time or the network id of the forked blockchain if configured)
 * `--db`: Specify a path to a directory to save the chain database. If a database already exists, ganache-cli will initialize that chain instead of creating a new one.
 * `--debug`: Output VM opcodes for debugging
@@ -152,6 +153,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"total_accounts"`: `number` - Number of accounts to generate at startup.
 * `"fork"`: `string` or `object` - Fork from another currently running Ethereum client at a given block.  When a `string`, input should be the HTTP location and port of the other client, e.g. `http://localhost:8545`. You can optionally specify the block to fork from using an `@` sign: `http://localhost:8545@1599200`. Can also be a `Web3 Provider` object, optionally used in conjunction with the `fork_block_number` option below.
 * `"fork_block_number"`: `string` or `number` - Block number the provider should fork from, when the `fork` option is specified. If the `fork` option is specified as a string including the `@` sign and a block number, the block number in the `fork` parameter takes precedence.
+`forkCacheSize`: `number` - The maximum size, in bytes, of the in-memory cache for queries on a chain fork. Defaults to `1_073_741_824` bytes (1 gigabyte). You can set this to `0` to disable caching (not recommended), or to `-1` for unlimited (will be limited by your node/browser process).
 * `"network_id"`: Specify the network id ganache-core will use to identify itself (defaults to the current time or the network id of the forked blockchain if configured)
 * `"time"`: `Date` - Date that the first block should start. Use this feature, along with the `evm_increaseTime` method to test time-dependent code.
 * `"locked"`: `boolean` - whether or not accounts are locked by default.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you came here expecting to find the TestRPC, you're in the right place! Truff
 
 ## Installation
 
-`ganache-cli` is written in JavaScript and distributed as a Node.js package via `npm`. Make sure you have Node.js (>= v6.11.5) installed.
+`ganache-cli` is written in JavaScript and distributed as a Node.js package via `npm`. Make sure you have Node.js (>= v8) installed.
 
 Using npm:
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"gasLimit"`: `String::hex | number` Sets the block gas limit. Must be specified as a `hex` string or `number`. Defaults to `"0x6691b7"`.
 * `"callGasLimit"`: `number` Sets the transaction gas limit for `eth_call` and `eth_estimateGas` calls. Must be specified as a `hex` string. Defaults to `"0x1fffffffffffff"` (`Number.MAX_SAFE_INTEGER`).
 * `"keepAliveTimeout"`:  `number` If using `.server()` - Sets the HTTP server's `keepAliveTimeout` in milliseconds. See the [NodeJS HTTP docs](https://nodejs.org/api/http.html#http_server_keepalivetimeout) for details. `5000` by default.
+* `"deasync"`:  `boolean` Synchronizes ganache server startup. Useful in certain scenarios - see ganache-cli issue [#733](https://github.com/trufflesuite/ganache-cli/issues/733).
 
 ## Implemented Methods
 

--- a/args.js
+++ b/args.js
@@ -80,6 +80,12 @@ module.exports = exports = function(yargs, version, isDocker) {
       describe: "Fork from another currently running Ethereum client at a given block. Input should be the HTTP location and port of the other client, e.g. 'http://localhost:8545' or optionally provide a block number 'http://localhost:8545@1599200'",
       default: false
     })
+    .option('forkCacheSize', {
+      group: 'Chain:',
+      type: 'number',
+      describe: "The maximum size, in bytes, of the in-memory cache for queries on a chain fork. Defaults to `1_073_741_824` bytes (1 gigabyte). You can set this to `0` to disable caching (not recommended), or to `-1` for unlimited (will be limited by your node process).",
+      default: 1073741824
+    })
     .option('db', {
       group: 'Chain:',
       describe: 'Directory of chain database; creates one if it doesn\'t exist',

--- a/args.js
+++ b/args.js
@@ -205,12 +205,6 @@ module.exports = exports = function(yargs, version, isDocker) {
       type: 'boolean',
       default: false
     })
-    .option('deasync', {
-      group: 'Other::',
-      describe: 'Synchronize ganache server startup. Useful in certain scenarios (see ganache-cli issue #733).',
-      type: 'boolean',
-      default: false
-    })
     .showHelpOnFail(false, 'Specify -? or --help for available options')
     .help('help')
     .alias('help', '?')

--- a/args.js
+++ b/args.js
@@ -205,6 +205,12 @@ module.exports = exports = function(yargs, version, isDocker) {
       type: 'boolean',
       default: false
     })
+    .option('deasync', {
+      group: 'Other::',
+      describe: 'Synchronize ganache server startup. Useful in certain scenarios (see ganache-cli issue #733).',
+      type: 'boolean',
+      default: false
+    })
     .showHelpOnFail(false, 'Specify -? or --help for available options')
     .help('help')
     .alias('help', '?')

--- a/cli.js
+++ b/cli.js
@@ -85,6 +85,7 @@ var options = {
   accounts: parseAccounts(argv.account),
   unlocked_accounts: argv.unlock,
   fork: argv.f,
+  forkCacheSize: argv.forkCacheSize,
   hardfork: argv.k,
   network_id: argv.i,
   verbose: argv.v,
@@ -221,10 +222,17 @@ function startGanache(err, result) {
     console.log("");
     console.log("Forked Chain");
     console.log("==================");
-    console.log("Location:    " + state.blockchain.options.fork);
-    console.log("Block:       " + to.number(state.blockchain.forkBlockNumber));
-    console.log("Network ID:  " + state.net_version);
-    console.log("Time:        " + (state.blockchain.startTime || new Date()).toString());
+    console.log("Location:       " + state.blockchain.options.fork);
+    console.log("Block:          " + to.number(state.blockchain.forkBlockNumber));
+    console.log("Network ID:     " + state.net_version);
+    console.log("Time:           " + (state.blockchain.startTime || new Date()).toString());
+    let maxCacheSize;
+    if (options.forkCacheSize === -1) {
+      maxCacheSize = "∞";
+    } else {
+      maxCacheSize = options.forkCacheSize + " bytes";
+    }
+    console.log("Max Cache Size: " + maxCacheSize);
   }
 
   console.log("");

--- a/cli.js
+++ b/cli.js
@@ -19,12 +19,6 @@ var detailedVersion = "Ganache CLI v" + pkg.version + " (ganache-core: " + ganac
 
 var isDocker = "DOCKER" in process.env && process.env.DOCKER.toLowerCase() === "true";
 var argv = initArgs(yargs, detailedVersion, isDocker).argv;
-var deasync;
-try {
-  deasync = argv.deasync ? require("deasync") : false;
-} catch(e) {
-  deasync = false;
-}
 
 function parseAccounts(accounts) {
   function splitAccount(account) {
@@ -238,10 +232,4 @@ function startGanache(err, result) {
   console.log("Listening on " + options.hostname + ":" + options.port);
 }
 
-if (deasync) {
-  const listen = deasync(server.listen);
-  const result = listen(options.port, options.hostname);
-  startGanache(null, result);
-} else {
-  server.listen(options.port, options.hostname, startGanache);
-}
+server.listen(options.port, options.hostname, startGanache);

--- a/cli.js
+++ b/cli.js
@@ -99,7 +99,6 @@ var options = {
   keepAliveTimeout: argv.keepAliveTimeout
 }
 
-var fork_address;
 var server = ganache.server(options);
 
 console.log(detailedVersion);
@@ -222,7 +221,7 @@ function startGanache(err, result) {
     console.log("");
     console.log("Forked Chain");
     console.log("==================");
-    console.log("Location:    " + fork_address);
+    console.log("Location:    " + state.blockchain.options.fork);
     console.log("Block:       " + to.number(state.blockchain.forkBlockNumber));
     console.log("Network ID:  " + state.net_version);
     console.log("Time:        " + (state.blockchain.startTime || new Date()).toString());

--- a/cli.js
+++ b/cli.js
@@ -13,8 +13,6 @@ try {
   ganache = require("./build/ganache-core.node.cli.js");
 }
 var to = ganache.to;
-var URL = require("url");
-var fs = require("fs");
 var initArgs = require("./args")
 
 var detailedVersion = "Ganache CLI v" + pkg.version + " (ganache-core: " + ganache.version + ")";

--- a/cli.js
+++ b/cli.js
@@ -102,23 +102,6 @@ var options = {
 }
 
 var fork_address;
-
-// If we're forking from another client, don't try to use the same port.
-if (options.fork) {
-  var split = options.fork.split("@");
-  fork_address = split[0];
-  var block;
-  if (split.length > 1) {
-    block = split[1];
-  }
-
-  if (URL.parse(fork_address).port == options.port) {
-    options.port = (parseInt(options.port) + 1);
-  }
-
-  options.fork = fork_address + (block != null ? "@" + block : "");
-}
-
 var server = ganache.server(options);
 
 console.log(detailedVersion);

--- a/package-lock.json
+++ b/package-lock.json
@@ -933,6 +933,15 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "deasync": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
+      "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^1.7.1"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -17254,6 +17263,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-addon-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
     },
     "node-libs-browser": {
       "version": "2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,38 +5,29 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
+      "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.3"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
+      "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
+      "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.10.3",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
-      }
-    },
-    "@babel/runtime": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
       }
     },
     "@nodelib/fs.scandir": {
@@ -66,35 +57,35 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
-      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0"
+        "@octokit/types": "^5.0.0"
       }
     },
     "@octokit/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-uvzmkemQrBgD8xuGbjhxzJN1darJk9L2cS+M99cHrDG2jlSVpxNJVhoV86cXdYBqdHCc9Z995uLCczaaHIYA6Q==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
+      "integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
       "dev": true,
       "requires": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.4.0",
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^5.0.0",
         "before-after-hook": "^2.1.0",
         "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
-      "integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.3.tgz",
+      "integrity": "sha512-Y900+r0gIz+cWp6ytnkibbD95ucEzDSKzlEnaWS52hbCDNcCJYO5mRmWW7HRAnDc7am+N/5Lnd8MppSaTYx1Yg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.11.1",
+        "@octokit/types": "^5.0.0",
         "is-plain-object": "^3.0.0",
         "universal-user-agent": "^5.0.0"
       },
@@ -117,23 +108,23 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.4.0.tgz",
-      "integrity": "sha512-Du3hAaSROQ8EatmYoSAJjzAz3t79t9Opj/WY1zUgxVUGfIKn0AEjg+hlOLscF6fv6i/4y/CeUvsWgIfwMkTccw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.1.tgz",
+      "integrity": "sha512-qgMsROG9K2KxDs12CO3bySJaYoUu2aic90qpFrv7A8sEBzZ7UFGvdgPKiLw5gOPYEYbS0Xf8Tvf84tJutHPulQ==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^5.0.0",
         "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.0.tgz",
-      "integrity": "sha512-KoNxC3PLNar8UJwR+1VMQOw2IoOrrFdo5YOiDKnBhpVbKpw+zkBKNMNKwM44UWL25Vkn0Sl3nYIEGKY+gW5ebw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.3.tgz",
+      "integrity": "sha512-eKTs91wXnJH8Yicwa30jz6DF50kAh7vkcqCQ9D7/tvBAP5KKkg6I2nNof8Mp/65G0Arjsb4QcOJcIEQY+rK1Rg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.12.1"
+        "@octokit/types": "^5.0.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -143,24 +134,35 @@
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.11.0.tgz",
-      "integrity": "sha512-D31cBYhlOt6Om2xNkCNZUjyWdaDKUfa4HwpLwL8Dnu8aDuVuuOPLUhFMUDE0GvfqlNQFrNtU7n5HaZm+KmRdsw==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
+      "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.16.0",
+        "@octokit/types": "^4.1.6",
         "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "4.1.10",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
+          "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
     "@octokit/request": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
-      "integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.5.tgz",
+      "integrity": "sha512-atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^2.11.1",
+        "@octokit/types": "^5.0.0",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
@@ -186,32 +188,32 @@
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
-      "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^5.0.1",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
     "@octokit/rest": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.9.0.tgz",
-      "integrity": "sha512-Ff2jwS2OizWVaiCozOJevQ97V+mKjlQAt//lU6a/lhWDfHsZLXm/k1RsyTKVbyuiriDi7pg899wCU59nYfKnmQ==",
+      "version": "17.11.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.11.2.tgz",
+      "integrity": "sha512-4jTmn8WossTUaLfNDfXk4fVJgbz5JgZE8eCs4BvIb52lvIH8rpVMD1fgRCrHbSd6LRPE5JFZSfAEtszrOq3ZFQ==",
       "dev": true,
       "requires": {
         "@octokit/core": "^2.4.3",
         "@octokit/plugin-paginate-rest": "^2.2.0",
         "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "3.11.0"
+        "@octokit/plugin-rest-endpoint-methods": "3.17.0"
       }
     },
     "@octokit/types": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
-      "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.1.tgz",
+      "integrity": "sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -299,9 +301,9 @@
       "dev": true
     },
     "@semantic-release/github": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.0.6.tgz",
-      "integrity": "sha512-70fUj+t98AWRgeOG0j2kdguvaVyysOZRUmXykZBwkktSDm1UZ6YfelYFPuM9OJbKPuNjKsCsRXl5/wukDUg8PA==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.0.7.tgz",
+      "integrity": "sha512-Sai2UucYQ+5rJzKVEVJ4eiZNDdoo0/CzfpValBdeU5h97uJE7t4CoBTmUWkiXlPOx46CSw1+JhI+PHC1PUxVZw==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^17.0.0",
@@ -361,9 +363,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -372,9 +374,9 @@
           }
         },
         "execa": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.1.tgz",
-          "integrity": "sha512-SCjM/zlBdOK8Q5TIjOn6iEHZaPHFsMoTxXQ2nvUvtPnuohz3H2dIozSg+etNR98dGoYUp2ENSKLL/XaMmbxVgw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -528,9 +530,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
-      "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
+      "version": "14.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
+      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1522,9 +1524,9 @@
       "dev": true
     },
     "compare-func": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
+      "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
@@ -1608,11 +1610,12 @@
           "dev": true
         },
         "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
           "dev": true,
           "requires": {
+            "inherits": "^2.0.4",
             "readable-stream": "2 || 3"
           }
         }
@@ -1650,11 +1653,12 @@
           "dev": true
         },
         "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
           "dev": true,
           "requires": {
+            "inherits": "^2.0.4",
             "readable-stream": "2 || 3"
           }
         }
@@ -2005,9 +2009,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -2016,9 +2020,9 @@
           }
         },
         "execa": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.1.tgz",
-          "integrity": "sha512-SCjM/zlBdOK8Q5TIjOn6iEHZaPHFsMoTxXQ2nvUvtPnuohz3H2dIozSg+etNR98dGoYUp2ENSKLL/XaMmbxVgw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -2354,9 +2358,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2543,9 +2547,9 @@
       }
     },
     "fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
       "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
@@ -4372,6 +4376,7 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -9704,6 +9709,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "scrypt": "^6.0.2",
             "scryptsy": "^1.2.1"
           }
         },
@@ -12076,9 +12082,9 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-      "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -12292,9 +12298,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
     "import-fresh": {
@@ -12982,9 +12988,9 @@
       }
     },
     "marked": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
-      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
+      "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA==",
       "dev": true
     },
     "marked-terminal": {
@@ -13021,9 +13027,9 @@
           }
         },
         "chalk": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -13152,9 +13158,9 @@
       "dev": true
     },
     "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -13189,9 +13195,9 @@
       }
     },
     "mime": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
-      "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
       "dev": true
     },
     "mimic-fn": {
@@ -13200,9 +13206,9 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "min-indent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
     "minimalistic-assert": {
@@ -13231,13 +13237,14 @@
       "dev": true
     },
     "minimist-options": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
-      "integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "dev": true,
       "requires": {
         "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "arrify": {
@@ -17680,12 +17687,6 @@
         "esprima": "~4.0.0"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -17887,6 +17888,7 @@
       "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
       "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "nan": "^2.0.8"
       }
@@ -17907,9 +17909,9 @@
       }
     },
     "semantic-release": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.0.7.tgz",
-      "integrity": "sha512-F6FzJI1yiGavzCTXir4yPthK/iozZPJ4myUYndiHhSHbmOcCSJ2m7V+P6sFwVpDpQKQp1Q31M68sTJ/Q/27Bow==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.1.1.tgz",
+      "integrity": "sha512-9H+207eynBJElrQBHySZm+sIEoJeUhPA2zU4cdlY1QSInd2lnE8GRD2ALry9EassE22c9WW+aCREwBhro5AIIg==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -17994,9 +17996,9 @@
           "dev": true
         },
         "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -18020,9 +18022,9 @@
           "dev": true
         },
         "execa": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.1.tgz",
-          "integrity": "sha512-SCjM/zlBdOK8Q5TIjOn6iEHZaPHFsMoTxXQ2nvUvtPnuohz3H2dIozSg+etNR98dGoYUp2ENSKLL/XaMmbxVgw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -18562,9 +18564,9 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -19013,14 +19015,11 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
-      "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
+      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3"
-      }
+      "optional": true
     },
     "union-value": {
       "version": "1.0.1",
@@ -19424,9 +19423,9 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "windows-release": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
-      "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
+      "integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0"
@@ -19480,13 +19479,10 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
-      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
     },
     "yargs": {
       "version": "13.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,178 +5,177 @@
   "requires": true,
   "dependencies": {
     "@webassemblyjs/ast": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5"
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+      "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+      "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+      "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+      "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.8.5"
+        "@webassemblyjs/wast-printer": "1.9.0"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+      "integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+      "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "mamacro": "^0.0.3"
+        "@webassemblyjs/ast": "1.9.0"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+      "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+      "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+      "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+      "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+      "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/helper-wasm-section": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-opt": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "@webassemblyjs/wast-printer": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/helper-wasm-section": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-opt": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "@webassemblyjs/wast-printer": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+      "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+      "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+      "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+      "integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-code-frame": "1.8.5",
-        "@webassemblyjs/helper-fsm": "1.8.5",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-code-frame": "1.9.0",
+        "@webassemblyjs/helper-fsm": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+      "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -193,18 +192,18 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "ajv": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-      "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -410,9 +409,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
     "big.js": {
@@ -545,18 +544,61 @@
       }
     },
     "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
+      "integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
+          "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
+          "dev": true
+        },
+        "elliptic": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "browserify-zlib": {
@@ -569,9 +611,9 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -596,9 +638,9 @@
       "dev": true
     },
     "cacache": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
@@ -658,9 +700,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -678,9 +720,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -815,13 +857,10 @@
       }
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "^0.1.4"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -927,16 +966,11 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-      "dev": true
-    },
     "deasync": {
       "version": "0.1.20",
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
       "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"
@@ -1004,9 +1038,9 @@
       }
     },
     "des.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -1131,9 +1165,9 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "ethereumjs-util": {
@@ -1160,9 +1194,9 @@
       }
     },
     "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
       "dev": true
     },
     "evp_bytestokey": {
@@ -1332,21 +1366,21 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
     },
     "figures": {
@@ -1459,551 +1493,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
       }
     },
     "ganache-core": {
@@ -16963,9 +16460,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "lcid": {
@@ -17026,12 +16523,6 @@
         "pify": "^4.0.1",
         "semver": "^5.6.0"
       }
-    },
-    "mamacro": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
-      "dev": true
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -17187,18 +16678,18 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -17267,7 +16758,8 @@
     "node-addon-api": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+      "optional": true
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -17479,9 +16971,9 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
     "parallel-transform": {
@@ -17496,9 +16988,9 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
@@ -18131,12 +17623,12 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
+        "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -18300,9 +17792,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.0.tgz",
-      "integrity": "sha512-YMJyZ/KsqA1LVS0z5m9W1//n4zo6iYqvBSAvss07e4BfHl9ZdQWUeXN/Xh1nGzMO/CwS0zjANpOzR8KibBP9Pg==",
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
+      "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -18325,18 +17817,6 @@
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
         "worker-farm": "^1.7.0"
-      },
-      "dependencies": {
-        "webpack-sources": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-          "dev": true,
-          "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
-          }
-        }
       }
     },
     "through": {
@@ -18356,9 +17836,9 @@
       }
     },
     "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -18510,9 +17990,9 @@
       }
     },
     "upath": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
     },
     "uri-js": {
@@ -18584,51 +18064,51 @@
       "dev": true
     },
     "vm-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
     },
     "watchpack": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
+      "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
+        "chokidar": "^2.1.8",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       }
     },
     "webpack": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.3.tgz",
-      "integrity": "sha512-xggQPwr9ILlXzz61lHzjvgoqGU08v5+Wnut19Uv3GaTtzN4xBTcwnobodrXE142EL1tOiS5WVEButooGzcQzTA==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
+      "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chrome-trace-event": "^1.0.0",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.0",
+        "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "micromatch": "^3.1.8",
-        "mkdirp": "~0.5.0",
-        "neo-async": "^2.5.0",
-        "node-libs-browser": "^2.0.0",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.3",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
-        "tapable": "^1.1.0",
-        "terser-webpack-plugin": "^1.1.0",
-        "watchpack": "^1.5.0",
-        "webpack-sources": "^1.3.0"
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.6.1",
+        "webpack-sources": "^1.4.1"
       }
     },
     "webpack-cli": {
@@ -18778,9 +18258,9 @@
       }
     },
     "webpack-sources": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-      "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
       "dev": true,
       "requires": {
         "source-list-map": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ganache-cli",
-  "version": "6.9.1",
+  "version": "6.10.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,553 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
+      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uvzmkemQrBgD8xuGbjhxzJN1darJk9L2cS+M99cHrDG2jlSVpxNJVhoV86cXdYBqdHCc9Z995uLCczaaHIYA6Q==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^2.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
+      "integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.11.1",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.4.0.tgz",
+      "integrity": "sha512-Du3hAaSROQ8EatmYoSAJjzAz3t79t9Opj/WY1zUgxVUGfIKn0AEjg+hlOLscF6fv6i/4y/CeUvsWgIfwMkTccw==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^2.0.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.0.tgz",
+      "integrity": "sha512-KoNxC3PLNar8UJwR+1VMQOw2IoOrrFdo5YOiDKnBhpVbKpw+zkBKNMNKwM44UWL25Vkn0Sl3nYIEGKY+gW5ebw==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.12.1"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
+      "dev": true
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.11.0.tgz",
+      "integrity": "sha512-D31cBYhlOt6Om2xNkCNZUjyWdaDKUfa4HwpLwL8Dnu8aDuVuuOPLUhFMUDE0GvfqlNQFrNtU7n5HaZm+KmRdsw==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.16.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
+      "integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^2.11.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
+      "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.9.0.tgz",
+      "integrity": "sha512-Ff2jwS2OizWVaiCozOJevQ97V+mKjlQAt//lU6a/lhWDfHsZLXm/k1RsyTKVbyuiriDi7pg899wCU59nYfKnmQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/core": "^2.4.3",
+        "@octokit/plugin-paginate-rest": "^2.2.0",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "3.11.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+      "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
+    "@semantic-release/commit-analyzer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",
+      "integrity": "sha512-5bJma/oB7B4MtwUkZC2Bf7O1MHfi4gWe4mA+MIQ3lsEV0b422Bvl1z5HRpplDnMLHH3EXMoRdEng6Ds5wUqA3A==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.7",
+        "debug": "^4.0.0",
+        "import-from": "^3.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "@semantic-release/error": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+      "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+      "dev": true
+    },
+    "@semantic-release/github": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.0.6.tgz",
+      "integrity": "sha512-70fUj+t98AWRgeOG0j2kdguvaVyysOZRUmXykZBwkktSDm1UZ6YfelYFPuM9OJbKPuNjKsCsRXl5/wukDUg8PA==",
+      "dev": true,
+      "requires": {
+        "@octokit/rest": "^17.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "bottleneck": "^2.18.1",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "fs-extra": "^9.0.0",
+        "globby": "^11.0.0",
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "issue-parser": "^6.0.0",
+        "lodash": "^4.17.4",
+        "mime": "^2.4.3",
+        "p-filter": "^2.0.0",
+        "p-retry": "^4.0.0",
+        "url-join": "^4.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@semantic-release/npm": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.5.tgz",
+      "integrity": "sha512-D+oEmsx9aHE1q806NFQwSC9KdBO8ri/VO99eEz0wWbX2jyLqVyWr7t0IjKC8aSnkkQswg/4KN/ZjfF6iz1XOpw==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^2.2.0",
+        "aggregate-error": "^3.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "nerf-dart": "^1.0.0",
+        "normalize-url": "^5.0.0",
+        "npm": "^6.10.3",
+        "rc": "^1.2.8",
+        "read-pkg": "^5.0.0",
+        "registry-auth-token": "^4.0.0",
+        "semver": "^7.1.2",
+        "tempy": "^0.5.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.1.tgz",
+          "integrity": "sha512-SCjM/zlBdOK8Q5TIjOn6iEHZaPHFsMoTxXQ2nvUvtPnuohz3H2dIozSg+etNR98dGoYUp2ENSKLL/XaMmbxVgw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@semantic-release/release-notes-generator": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.1.tgz",
+      "integrity": "sha512-bOoTiH6SiiR0x2uywSNR7uZcRDl22IpZhj+Q5Bn0v+98MFtOMhCxFhbrKQjhbYoZw7vps1mvMRmFkp/g6R9cvQ==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "^5.0.0",
+        "conventional-changelog-writer": "^4.0.0",
+        "conventional-commits-filter": "^2.0.0",
+        "conventional-commits-parser": "^3.0.0",
+        "debug": "^4.0.0",
+        "get-stream": "^5.0.0",
+        "import-from": "^3.0.0",
+        "into-stream": "^5.0.0",
+        "lodash": "^4.17.4",
+        "read-pkg-up": "^7.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+      "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -191,11 +738,57 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "acorn": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
       "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
     },
     "ajv": {
       "version": "6.12.2",
@@ -240,6 +833,12 @@
         "color-convert": "^1.9.0"
       }
     },
+    "ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "dev": true
+    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -267,6 +866,12 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
+    "argv-formatter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+      "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -285,10 +890,28 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
     "asn1.js": {
@@ -339,6 +962,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -414,6 +1043,12 @@
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+      "dev": true
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -452,6 +1087,12 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -677,10 +1318,37 @@
         "unset-value": "^1.0.0"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
+    "cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+      "dev": true,
+      "requires": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -766,6 +1434,12 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -773,6 +1447,15 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
       }
     },
     "cli-width": {
@@ -820,6 +1503,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -831,6 +1520,16 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "compare-func": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+      "dev": true,
+      "requires": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
+      }
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -868,6 +1567,99 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
+    "conventional-changelog-angular": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
+      "integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-writer": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
+      "integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^2.0.6",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.7.6",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^7.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^3.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
+    "conventional-commits-filter": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz",
+      "integrity": "sha512-4g+sw8+KA50/Qwzfr0hL5k5NWxqtrOVw4DDk3/h6L85a9Gz0/Eqp3oP+CWCNfesBvZZZEFHF7OTEbRe+yYSyKw==",
+      "dev": true,
+      "requires": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.0"
+      }
+    },
+    "conventional-commits-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.1.0.tgz",
+      "integrity": "sha512-RSo5S0WIwXZiRxUGTPuYFbqvrR4vpJ1BDdTlthFgvHt5kEdnd1+pdvwWphWn57/oIl4V72NMmOocFqqJ8mFFhA==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^7.0.0",
+        "split2": "^2.0.0",
+        "through2": "^3.0.0",
+        "trim-off-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -893,6 +1685,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -960,10 +1765,22 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
     "deasync": {
@@ -990,10 +1807,34 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "define-property": {
@@ -1037,6 +1878,12 @@
         }
       }
     },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -1058,11 +1905,29 @@
         "randombytes": "^2.0.0"
       }
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
+    },
+    "dot-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -1072,6 +1937,15 @@
         "browserify-aes": "^1.0.6",
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4"
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
       }
     },
     "duplexify": {
@@ -1130,6 +2004,109 @@
         "tapable": "^1.0.0"
       }
     },
+    "env-ci": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
+      "integrity": "sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==",
+      "dev": true,
+      "requires": {
+        "execa": "^4.0.0",
+        "java-properties": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.1.tgz",
+          "integrity": "sha512-SCjM/zlBdOK8Q5TIjOn6iEHZaPHFsMoTxXQ2nvUvtPnuohz3H2dIozSg+etNR98dGoYUp2ENSKLL/XaMmbxVgw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -1137,6 +2114,15 @@
       "dev": true,
       "requires": {
         "prr": "~1.0.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -1154,6 +2140,12 @@
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -1371,11 +2363,88 @@
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -1439,6 +2508,15 @@
         "locate-path": "^3.0.0"
       }
     },
+    "find-versions": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
+      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^2.0.0"
+      }
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -1472,6 +2550,18 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -15952,6 +17042,31 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "git-log-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+      "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+      "dev": true,
+      "requires": {
+        "argv-formatter": "~1.0.0",
+        "spawn-error-forwarder": "~1.0.0",
+        "split2": "~1.0.0",
+        "stream-combiner2": "~1.1.1",
+        "through2": "~2.0.0",
+        "traverse": "~0.6.6"
+      },
+      "dependencies": {
+        "split2": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+          "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
+          "dev": true,
+          "requires": {
+            "through2": "~2.0.0"
+          }
+        }
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -15993,10 +17108,51 @@
       "integrity": "sha512-y+shkf4InI7mPRHSo2b/k6ix6+NLDtyccYv86whhxrSGX9wjPX1VMITmrDbE1eh7zkzhiWtW2sHklJYoQ62Cxg==",
       "dev": true
     },
+    "globby": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+      "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
+      }
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
       "dev": true
     },
     "has-flag": {
@@ -16065,10 +17221,86 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hook-std": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
+      "integrity": "sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
     "iconv-lite": {
@@ -16091,6 +17323,47 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
+    },
+    "ignore": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -16162,6 +17435,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -16182,6 +17461,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "inquirer": {
       "version": "6.4.1",
@@ -16239,6 +17524,24 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
+    "into-stream": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
+      "integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
+      "dev": true,
+      "requires": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      },
+      "dependencies": {
+        "p-is-promise": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+          "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+          "dev": true
+        }
+      }
+    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -16263,6 +17566,12 @@
           }
         }
       }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -16369,6 +17678,18 @@
         }
       }
     },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -16388,6 +17709,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-text-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+      "dev": true,
+      "requires": {
+        "text-extensions": "^1.0.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -16418,6 +17748,25 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "issue-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
+      "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+      "dev": true,
+      "requires": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.uniqby": "^4.7.0"
+      }
+    },
+    "java-properties": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+      "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+      "dev": true
+    },
     "js-scrypt": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/js-scrypt/-/js-scrypt-0.2.0.tgz",
@@ -16426,6 +17775,12 @@
       "requires": {
         "generic-pool": "~2.0.4"
       }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -16439,6 +17794,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -16447,6 +17808,22 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
     },
     "keccak": {
       "version": "1.4.0",
@@ -16471,6 +17848,42 @@
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "requires": {
         "invert-kv": "^2.0.0"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "loader-runner": {
@@ -16505,6 +17918,48 @@
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
+      "dev": true
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
+    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -16513,6 +17968,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "macos-release": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+      "dev": true
     },
     "make-dir": {
       "version": "2.1.0",
@@ -16538,6 +17999,12 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
+    "map-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -16545,6 +18012,93 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "marked": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
+      "dev": true
+    },
+    "marked-terminal": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.0.tgz",
+      "integrity": "sha512-5KllfAOW02WS6hLRQ7cNvGOxvKW1BKuXELH4EtbWfyWgxQhROoMxEvuQ/3fTgkNjledR0J48F4HbapvYp1zWkQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.3.1",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.0.0",
+        "cli-table": "^0.3.1",
+        "node-emoji": "^1.10.0",
+        "supports-hyperlinks": "^2.1.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.11.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
       }
     },
     "md5.js": {
@@ -16577,6 +18131,65 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "meow": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "arrify": "^2.0.1",
+        "camelcase": "^6.0.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -16608,10 +18221,22 @@
         "brorand": "^1.0.1"
       }
     },
+    "mime": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
+      "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -16637,6 +18262,24 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
+      "integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        }
+      }
     },
     "mississippi": {
       "version": "3.0.0",
@@ -16694,6 +18337,12 @@
         }
       }
     },
+    "modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -16750,6 +18399,12 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "nerf-dart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+      "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -16760,6 +18415,21 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
       "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
       "optional": true
+    },
+    "node-emoji": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "dev": true,
+      "requires": {
+        "lodash.toarray": "^4.4.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -16806,11 +18476,3578 @@
       "integrity": "sha1-x5fvUQle1YWZArFX9jhPY2HgWug=",
       "dev": true
     },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "dev": true
+        }
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "normalize-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.0.0.tgz",
+      "integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw==",
+      "dev": true
+    },
+    "npm": {
+      "version": "6.14.5",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.5.tgz",
+      "integrity": "sha512-CDwa3FJd0XJpKDbWCST484H+mCNjF26dPrU+xnREW+upR0UODjMEfXPl3bxWuAwZIX6c2ASg1plLO7jP8ehWeA==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.3.5",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "^2.0.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.7",
+        "bluebird": "^3.5.5",
+        "byte-size": "^5.0.1",
+        "cacache": "^12.0.3",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.4",
+        "ci-info": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "^3.0.3",
+        "columnify": "~1.5.4",
+        "config-chain": "^1.1.12",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.5.1",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.3.0",
+        "glob": "^7.1.6",
+        "graceful-fs": "^4.2.4",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.8.8",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
+        "inflight": "~1.0.6",
+        "inherits": "^2.0.4",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^3.0.0",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^4.0.7",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "libnpx": "^10.2.2",
+        "lock-verify": "^2.1.0",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^5.1.1",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.5",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^5.1.0",
+        "nopt": "^4.0.3",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.2",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.4",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.8",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.4",
+        "npm-registry-fetch": "^4.0.4",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.1",
+        "osenv": "^0.1.5",
+        "pacote": "^9.5.12",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.8.2",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "^1.0.5",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.1.1",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.6.0",
+        "readdir-scoped-modules": "^1.1.0",
+        "request": "^2.88.0",
+        "retry": "^0.12.0",
+        "rimraf": "^2.7.1",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.7.1",
+        "sha": "^3.0.0",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.1",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.13",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "~1.1.0",
+        "unique-filename": "^1.1.1",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.3.3",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
+          }
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "agent-base": {
+          "version": "4.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "agentkeepalive": {
+          "version": "3.5.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "humanize-ms": "^1.2.1"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "ansicolors": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ansistyles": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "bin-links": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.3.0",
+            "graceful-fs": "^4.1.15",
+            "npm-normalize-package-bin": "^1.0.0",
+            "write-file-atomic": "^2.3.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.5",
+          "bundled": true,
+          "dev": true
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "builtins": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "byline": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "byte-size": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cacache": {
+          "version": "12.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          }
+        },
+        "call-limit": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chownr": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cidr-regex": {
+          "version": "2.0.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cli-columns": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "cli-table3": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "cmd-shim": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-name": "^1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "colors": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "columnify": {
+          "version": "1.5.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "config-chain": {
+          "version": "1.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "capture-stack-trace": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "clone": "^1.0.2"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "^2.0.0",
+            "wrappy": "1"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "editor": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "env-paths": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "err-code": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.8",
+          "bundled": true,
+          "dev": true
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "figgy-pudding": {
+          "version": "3.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "find-npm-prefix": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "fs-minipass": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
+          }
+        },
+        "fs-vacuum": {
+          "version": "1.2.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "genfun": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "gentle-fs": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
+            "cmd-shim": "^3.0.3",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "bundled": true,
+          "dev": true
+        },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true,
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agent-base": "4",
+            "debug": "3.1.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "humanize-ms": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "^2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "iferr": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ignore-walk": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "infer-owner": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true
+        },
+        "init-package-json": {
+          "version": "1.10.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "ip-regex": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "is-ci": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ci-info": "^1.5.0"
+          },
+          "dependencies": {
+            "ci-info": {
+              "version": "1.6.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "is-cidr": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cidr-regex": "^2.0.10"
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-retry-allowed": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "package-json": "^4.0.0"
+          }
+        },
+        "lazy-property": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "libcipm": {
+          "version": "4.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "ini": "^1.3.5",
+            "lock-verify": "^2.0.2",
+            "mkdirp": "^0.5.1",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "pacote": "^9.1.0",
+            "read-package-json": "^2.0.13",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.6.0"
+          }
+        },
+        "libnpm": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.3",
+            "find-npm-prefix": "^1.0.2",
+            "libnpmaccess": "^3.0.2",
+            "libnpmconfig": "^1.2.1",
+            "libnpmhook": "^5.0.3",
+            "libnpmorg": "^1.0.1",
+            "libnpmpublish": "^1.1.2",
+            "libnpmsearch": "^2.0.2",
+            "libnpmteam": "^1.0.2",
+            "lock-verify": "^2.0.2",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "npm-profile": "^4.0.2",
+            "npm-registry-fetch": "^4.0.0",
+            "npmlog": "^4.1.2",
+            "pacote": "^9.5.3",
+            "read-package-json": "^2.0.13",
+            "stringify-package": "^1.0.0"
+          }
+        },
+        "libnpmaccess": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "get-stream": "^4.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmconfig": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "find-up": "^3.0.0",
+            "ini": "^1.3.5"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "libnpmhook": {
+          "version": "5.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmpublish": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0",
+            "semver": "^5.5.1",
+            "ssri": "^6.0.1"
+          }
+        },
+        "libnpmsearch": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmteam": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpx": {
+          "version": "10.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lock-verify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-package-arg": "^6.1.0",
+            "semver": "^5.4.1"
+          }
+        },
+        "lockfile": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._baseuniq": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0"
+          }
+        },
+        "lodash._createset": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._root": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.without": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "make-fetch-happen": {
+          "version": "5.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agentkeepalive": "^3.4.1",
+            "cacache": "^12.0.0",
+            "http-cache-semantics": "^3.8.1",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "node-fetch-npm": "^2.0.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^4.0.0",
+            "ssri": "^6.0.0"
+          }
+        },
+        "map-age-cleaner": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-defer": "^1.0.0"
+          }
+        },
+        "meant": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "4.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "mimic-fn": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.35.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.19",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.35.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
+          }
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "node-fetch-npm": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "json-parse-better-errors": "^1.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "node-gyp": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "env-paths": "^2.2.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.2",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.1.2",
+            "request": "^2.88.0",
+            "rimraf": "^2.6.3",
+            "semver": "^5.7.1",
+            "tar": "^4.4.12",
+            "which": "^1.3.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.10.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            }
+          }
+        },
+        "npm-audit-report": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cli-table3": "^0.5.0",
+            "console-control-strings": "^1.1.0"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-cache-filename": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "^2.3.0 || 3.x || 4 || 5"
+          }
+        },
+        "npm-lifecycle": {
+          "version": "3.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.15",
+            "node-gyp": "^5.0.2",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
+            "uid-number": "0.0.6",
+            "umask": "^1.1.0",
+            "which": "^1.3.1"
+          }
+        },
+        "npm-logical-tree": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-package-arg": {
+          "version": "6.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.7.1",
+            "osenv": "^0.1.5",
+            "semver": "^5.6.0",
+            "validate-npm-package-name": "^3.0.0"
+          }
+        },
+        "npm-packlist": {
+          "version": "1.4.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-pick-manifest": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "npm-package-arg": "^6.0.0",
+            "semver": "^5.4.1"
+          }
+        },
+        "npm-profile": {
+          "version": "4.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.2 || 2",
+            "figgy-pudding": "^3.4.1",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "4.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "JSONStream": "^1.3.4",
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.4.1",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
+            "npm-package-arg": "^6.1.0",
+            "safe-buffer": "^5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "npm-user-validate": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "opener": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "execa": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            }
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "p-defer": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-is-promise": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
+          }
+        },
+        "pacote": {
+          "version": "9.5.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.3",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
+            "minimatch": "^3.0.4",
+            "minipass": "^2.3.5",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-normalize-package-bin": "^1.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^3.0.0",
+            "npm-registry-fetch": "^4.0.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.1",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.2",
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.10",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
+          }
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-retry": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
+          },
+          "dependencies": {
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "promzard": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "read": "1"
+          }
+        },
+        "proto-list": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "protoduck": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "genfun": "^5.0.0"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "psl": {
+          "version": "1.1.29",
+          "bundled": true,
+          "dev": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "query-string": {
+          "version": "6.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "qw": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "read": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mute-stream": "~0.0.4"
+          }
+        },
+        "read-cmd-shim": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2"
+          }
+        },
+        "read-installed": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
+          }
+        },
+        "read-package-json": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "npm-normalize-package-bin": "^1.0.0"
+          }
+        },
+        "read-package-tree": {
+          "version": "5.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
+        "request": {
+          "version": "2.88.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "retry": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.1"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "^5.0.3"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "sha": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "smart-buffer": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "socks": {
+          "version": "2.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ip": "1.1.5",
+            "smart-buffer": "^4.1.0"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agent-base": "~4.2.1",
+            "socks": "~2.3.2"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "es6-promisify": "^5.0.0"
+              }
+            }
+          }
+        },
+        "sorted-object": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "sorted-union-stream": {
+          "version": "2.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
+          },
+          "dependencies": {
+            "from2": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "split-on-first": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "sshpk": {
+          "version": "1.14.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "ssri": {
+          "version": "6.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
+        "stream-each": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "stream-iterate": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "stringify-package": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.13",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tiny-relative-date": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "umask": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "unique-filename": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "unique-slug": "^2.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^1.0.0"
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "update-notifier": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "util-extend": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "util-promisify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "bundled": true,
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtins": "^1.0.3"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "wcwidth": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "defaults": "^1.0.3"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "widest-line": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          }
+        },
+        "worker-farm": {
+          "version": "1.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "errno": "~0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.1.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -16928,6 +22165,16 @@
         "mem": "^4.0.0"
       }
     },
+    "os-name": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "dev": true,
+      "requires": {
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -16938,6 +22185,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
+    "p-each-series": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+      "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+      "dev": true
+    },
+    "p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "requires": {
+        "p-map": "^2.0.0"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -16965,6 +22227,28 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true
+    },
+    "p-reduce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "dev": true
+    },
+    "p-retry": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -16987,6 +22271,15 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-asn1": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -16999,6 +22292,18 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "pascalcase": {
@@ -17035,6 +22340,18 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -17048,11 +22365,72 @@
         "sha.js": "^2.4.8"
       }
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
+    },
+    "pkg-conf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
     },
     "pkg-dir": {
       "version": "3.0.0",
@@ -17154,6 +22532,12 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -17164,6 +22548,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
     "randombytes": {
@@ -17183,6 +22573,91 @@
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
       }
     },
     "readable-stream": {
@@ -17219,6 +22694,31 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "redeyed": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+      "dev": true,
+      "requires": {
+        "esprima": "~4.0.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -17227,6 +22727,15 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "registry-auth-token": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
       }
     },
     "remove-trailing-separator": {
@@ -17256,6 +22765,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-cwd": {
       "version": "2.0.0",
@@ -17294,6 +22812,18 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -17329,6 +22859,12 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -17403,10 +22939,395 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "semantic-release": {
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.0.7.tgz",
+      "integrity": "sha512-F6FzJI1yiGavzCTXir4yPthK/iozZPJ4myUYndiHhSHbmOcCSJ2m7V+P6sFwVpDpQKQp1Q31M68sTJ/Q/27Bow==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/commit-analyzer": "^8.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/github": "^7.0.0",
+        "@semantic-release/npm": "^7.0.0",
+        "@semantic-release/release-notes-generator": "^9.0.0",
+        "aggregate-error": "^3.0.0",
+        "cosmiconfig": "^6.0.0",
+        "debug": "^4.0.0",
+        "env-ci": "^5.0.0",
+        "execa": "^4.0.0",
+        "figures": "^3.0.0",
+        "find-versions": "^3.0.0",
+        "get-stream": "^5.0.0",
+        "git-log-parser": "^1.2.0",
+        "hook-std": "^2.0.0",
+        "hosted-git-info": "^3.0.0",
+        "lodash": "^4.17.15",
+        "marked": "^1.0.0",
+        "marked-terminal": "^4.0.0",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^2.1.0",
+        "p-reduce": "^2.0.0",
+        "read-pkg-up": "^7.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.2",
+        "semver-diff": "^3.1.1",
+        "signale": "^1.2.1",
+        "yargs": "^15.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "execa": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.1.tgz",
+          "integrity": "sha512-SCjM/zlBdOK8Q5TIjOn6iEHZaPHFsMoTxXQ2nvUvtPnuohz3H2dIozSg+etNR98dGoYUp2ENSKLL/XaMmbxVgw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+    },
+    "semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "semver-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "2.1.2",
@@ -17497,6 +23418,23 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "signale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+      "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.2",
+        "figures": "^2.0.0",
+        "pkg-conf": "^2.1.0"
+      }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -17650,6 +23588,53 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "spawn-error-forwarder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+      "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -17657,6 +23642,15 @@
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
+      "requires": {
+        "through2": "^2.0.2"
       }
     },
     "ssri": {
@@ -17696,6 +23690,16 @@
       "dev": true,
       "requires": {
         "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
       }
     },
@@ -17763,10 +23767,22 @@
         "ansi-regex": "^4.1.0"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
     },
     "strip-hex-prefix": {
       "version": "1.0.0",
@@ -17775,6 +23791,21 @@
       "requires": {
         "is-hex-prefixed": "1.0.0"
       }
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
@@ -17785,11 +23816,70 @@
         "has-flag": "^3.0.0"
       }
     },
+    "supports-hyperlinks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+      "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
+    },
+    "temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "dev": true
+    },
+    "tempy": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.5.0.tgz",
+      "integrity": "sha512-VEY96x7gbIRfsxqsafy2l5yVxxp3PhwAGoWMyC2D2Zt5DmEv+2tGiPOrquNRpf21hhGnKLVEsuqleqiZmKG/qw==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.12.0",
+        "unique-string": "^2.0.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
+          "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+          "dev": true
+        }
+      }
     },
     "terser": {
       "version": "4.6.13",
@@ -17818,6 +23908,12 @@
         "webpack-sources": "^1.4.0",
         "worker-farm": "^1.7.0"
       }
+    },
+    "text-extensions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -17901,6 +23997,24 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "dev": true
+    },
+    "trim-off-newlines": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "dev": true
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -17913,11 +24027,27 @@
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
+    "type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
+      "integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.3"
+      }
     },
     "union-value": {
       "version": "1.0.1",
@@ -17948,6 +24078,30 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universal-user-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+      "dev": true,
+      "requires": {
+        "os-name": "^3.1.0"
+      }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -18028,6 +24182,12 @@
         }
       }
     },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -18062,6 +24222,16 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
       "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
       "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "vm-browserify": {
       "version": "1.1.2",
@@ -18280,6 +24450,21 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
+    "windows-release": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
+      "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -18320,6 +24505,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
+      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
     },
     "yargs": {
       "version": "13.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18508,6 +18508,12 @@
       "integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw==",
       "dev": true
     },
+    "notp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/notp/-/notp-2.0.3.tgz",
+      "integrity": "sha1-qf0R4lz+HMs5/GaJVE7kwQ75pXc=",
+      "dev": true
+    },
     "npm": {
       "version": "6.14.5",
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.5.tgz",
@@ -23913,6 +23919,12 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+      "dev": true
+    },
+    "thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha1-TKL//AKlEpDSdEueP1V2k8prYno=",
       "dev": true
     },
     "through": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1783,16 +1783,6 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
-    "deasync": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
-      "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
-      "optional": true,
-      "requires": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      }
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -18409,12 +18399,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
-      "optional": true
     },
     "node-emoji": {
       "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
-      "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.3"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
-      "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
-      "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.3",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -80,51 +80,50 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.3.tgz",
-      "integrity": "sha512-Y900+r0gIz+cWp6ytnkibbD95ucEzDSKzlEnaWS52hbCDNcCJYO5mRmWW7HRAnDc7am+N/5Lnd8MppSaTYx1Yg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
       "dev": true,
       "requires": {
         "@octokit/types": "^5.0.0",
-        "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^5.0.0"
+        "is-plain-object": "^4.0.0",
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
           "dev": true
         }
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.1.tgz",
-      "integrity": "sha512-qgMsROG9K2KxDs12CO3bySJaYoUu2aic90qpFrv7A8sEBzZ7UFGvdgPKiLw5gOPYEYbS0Xf8Tvf84tJutHPulQ==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.3.tgz",
+      "integrity": "sha512-JyYvi3j2tOb5ofASEpcg1Advs07H+Ag+I+ez7buuZfNVAmh1IYcDTuxd4gnYH8S2PSGu+f5IdDGxMmkK+5zsdA==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^5.0.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+          "dev": true
+        }
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.3.tgz",
-      "integrity": "sha512-eKTs91wXnJH8Yicwa30jz6DF50kAh7vkcqCQ9D7/tvBAP5KKkg6I2nNof8Mp/65G0Arjsb4QcOJcIEQY+rK1Rg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
+      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^5.0.0"
+        "@octokit/types": "^5.2.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -155,34 +154,25 @@
       }
     },
     "@octokit/request": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.5.tgz",
-      "integrity": "sha512-atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
         "@octokit/types": "^5.0.0",
         "deprecation": "^2.0.0",
-        "is-plain-object": "^3.0.0",
+        "is-plain-object": "^4.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
           "dev": true
         }
       }
@@ -211,9 +201,9 @@
       }
     },
     "@octokit/types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.1.tgz",
-      "integrity": "sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.1.tgz",
+      "integrity": "sha512-PugtgEw8u++zAyBpDpSkR8K1OsT2l8QWp3ECL6bZHFoq9PfHDoKeGFWSuX2Z+Ghy93k1fkKf8tsmqNBv+8dEfQ==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -232,66 +222,6 @@
         "import-from": "^3.0.0",
         "lodash": "^4.17.4",
         "micromatch": "^4.0.2"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "@semantic-release/error": {
@@ -316,15 +246,6 @@
         "p-reduce": "^2.0.0"
       },
       "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
         "cross-spawn": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -336,19 +257,10 @@
             "which": "^2.0.1"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "execa": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -362,15 +274,6 @@
             "strip-final-newline": "^2.0.0"
           }
         },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
         "get-stream": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
@@ -380,32 +283,10 @@
             "pump": "^3.0.0"
           }
         },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "npm-run-path": {
@@ -415,15 +296,6 @@
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
-          }
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
           }
         },
         "path-key": {
@@ -446,15 +318,6 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
         },
         "which": {
           "version": "2.0.2",
@@ -489,23 +352,6 @@
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
         "url-join": "^4.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "@semantic-release/npm": {
@@ -541,9 +387,9 @@
           }
         },
         "execa": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -572,12 +418,6 @@
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
         "npm-run-path": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -585,15 +425,6 @@
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
-          }
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
           }
         },
         "path-key": {
@@ -652,15 +483,6 @@
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "get-stream": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
@@ -669,12 +491,6 @@
           "requires": {
             "pump": "^3.0.0"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
@@ -697,9 +513,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -924,29 +740,12 @@
       "dev": true
     },
     "agent-base": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
       "dev": true,
       "requires": {
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "aggregate-error": {
@@ -960,9 +759,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -978,16 +777,27 @@
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
       "version": "4.1.0",
@@ -1009,24 +819,14 @@
       "dev": true
     },
     "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "aproba": {
@@ -1131,7 +931,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -1225,10 +1026,11 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "dev": true,
+      "optional": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -1253,9 +1055,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
     },
     "bottleneck": {
       "version": "2.19.5",
@@ -1274,32 +1076,12 @@
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "fill-range": "^7.0.1"
       }
     },
     "brorand": {
@@ -1354,60 +1136,27 @@
       }
     },
     "browserify-sign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
-      "integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
       "dev": true,
       "requires": {
         "bn.js": "^5.1.1",
         "browserify-rsa": "^4.0.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.3",
         "inherits": "^2.0.4",
         "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0"
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-          "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
           "dev": true
-        },
-        "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-              "dev": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
         }
       }
     },
@@ -1468,6 +1217,23 @@
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
       }
     },
     "cache-base": {
@@ -1537,23 +1303,20 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+      "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
       }
     },
     "chownr": {
@@ -1628,9 +1391,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "cliui": {
@@ -1722,6 +1485,38 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "console-browserify": {
@@ -1764,27 +1559,11 @@
         "through2": "^3.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        },
-        "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
-          }
         }
       }
     },
@@ -1811,24 +1590,6 @@
         "split2": "^2.0.0",
         "through2": "^3.0.0",
         "trim-off-newlines": "^1.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
-        "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
-          }
-        }
       }
     },
     "copy-concurrently": {
@@ -1871,13 +1632,13 @@
       }
     },
     "create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "elliptic": "^6.5.3"
       }
     },
     "create-hash": {
@@ -1955,12 +1716,12 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -2107,6 +1868,38 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "duplexify": {
@@ -2119,12 +1912,44 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "elliptic": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -2141,28 +1966,70 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-      "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
+        "memory-fs": "^0.5.0",
         "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "env-ci": {
@@ -2187,9 +2054,9 @@
           }
         },
         "execa": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -2225,15 +2092,6 @@
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
-          }
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
           }
         },
         "path-key": {
@@ -2347,9 +2205,9 @@
       }
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
       "dev": true
     },
     "evp_bytestokey": {
@@ -2390,6 +2248,15 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -2407,6 +2274,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2427,6 +2300,15 @@
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
           }
         }
       }
@@ -2519,9 +2401,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-glob": {
@@ -2536,60 +2418,6 @@
         "merge2": "^1.3.0",
         "micromatch": "^4.0.2",
         "picomatch": "^2.2.1"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "fast-json-stable-stringify": {
@@ -2614,9 +2442,9 @@
       "dev": true
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -2628,26 +2456,12 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "to-regex-range": "^5.0.1"
       }
     },
     "find-cache-dir": {
@@ -2686,6 +2500,38 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -2711,6 +2557,38 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "fs-extra": {
@@ -2735,6 +2613,38 @@
         "iferr": "^0.1.5",
         "imurmurhash": "^0.1.4",
         "readable-stream": "1 || 2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -2744,20 +2654,16 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      }
+      "optional": true
     },
     "ganache-core": {
-      "version": "2.11.0-beta.0",
-      "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.11.0-beta.0.tgz",
-      "integrity": "sha512-/1+io16xIjzZjq/6JG7G6AQzfnj8nipzoZ5RdpATZOFr6elR7HJGEDFJxoGxk8Nhvv8YOkewVKpFVsudvJdr+g==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.11.2.tgz",
+      "integrity": "sha512-yZSMdR2xtqG2IdApeB6OywtMxwcHMp6Y5TUBwPyKe5/GripP8xnEpSKBluhxoyqEotg+Z2S8mjIXJyAm+NnMGw==",
       "dev": true,
       "requires": {
         "abstract-leveldown": "3.0.0",
@@ -2812,6 +2718,7 @@
           "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
           "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bignumber.js": "*"
           }
@@ -2826,10 +2733,28 @@
           }
         },
         "@types/node": {
-          "version": "13.5.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
-          "integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA==",
+          "version": "14.0.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+          "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
           "dev": true
+        },
+        "@types/pbkdf2": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+          "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/secp256k1": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+          "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
         },
         "@web3-js/scrypt-shim": {
           "version": "0.1.0",
@@ -2863,6 +2788,7 @@
           "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
           "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^2.2.0",
             "es5-ext": "^0.10.50",
@@ -2876,6 +2802,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -2884,13 +2811,8 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            },
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -2922,9 +2844,9 @@
           "optional": true
         },
         "ajv": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-          "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -2973,7 +2895,8 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "anymatch": {
           "version": "2.0.0",
@@ -2983,6 +2906,17 @@
           "requires": {
             "micromatch": "^3.1.4",
             "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
           }
         },
         "append-buffer": {
@@ -3129,6 +3063,7 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
@@ -3217,9 +3152,9 @@
           "dev": true
         },
         "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+          "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
           "dev": true
         },
         "babel-code-frame": {
@@ -3823,12 +3758,12 @@
           },
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "version": "0.5.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
               "dev": true,
               "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
               }
             },
             "source-map": {
@@ -4021,11 +3956,10 @@
           }
         },
         "base-x": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
-          "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -4057,7 +3991,8 @@
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
           "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "binary-extensions": {
           "version": "1.13.1",
@@ -4101,10 +4036,70 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true,
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
           }
+        },
+        "blakejs": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+          "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
+          "dev": true
         },
         "bluebird": {
           "version": "3.7.2",
@@ -4114,9 +4109,9 @@
           "optional": true
         },
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         },
         "body-parser": {
@@ -4124,6 +4119,7 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "content-type": "~1.0.4",
@@ -4142,6 +4138,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4150,7 +4147,8 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4243,35 +4241,37 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "randombytes": "^2.0.1"
           }
         },
-        "browserify-sha3": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
-          "integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
-          "dev": true,
-          "requires": {
-            "js-sha3": "^0.6.1",
-            "safe-buffer": "^5.1.1"
-          }
-        },
         "browserify-sign": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-          "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+          "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "^4.1.1",
-            "browserify-rsa": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "create-hmac": "^1.1.2",
-            "elliptic": "^6.0.0",
-            "inherits": "^2.0.1",
-            "parse-asn1": "^5.0.0"
+            "bn.js": "^5.1.1",
+            "browserify-rsa": "^4.0.1",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "elliptic": "^6.5.3",
+            "inherits": "^2.0.4",
+            "parse-asn1": "^5.1.5",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+              "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "browserslist": {
@@ -4289,7 +4289,6 @@
           "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
-          "optional": true,
           "requires": {
             "base-x": "^3.0.2"
           }
@@ -4299,7 +4298,6 @@
           "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
           "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bs58": "^4.0.0",
             "create-hash": "^1.1.0",
@@ -4307,9 +4305,9 @@
           }
         },
         "buffer": {
-          "version": "5.4.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -4321,6 +4319,7 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -4330,7 +4329,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -4349,7 +4349,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -4361,7 +4362,8 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -4373,7 +4375,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -4483,9 +4486,9 @@
           "dev": true
         },
         "caniuse-lite": {
-          "version": "1.0.30001023",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
-          "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
+          "version": "1.0.30001111",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz",
+          "integrity": "sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==",
           "dev": true
         },
         "caseless": {
@@ -4525,7 +4528,6 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -4534,20 +4536,12 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
-          },
-          "dependencies": {
-            "normalize-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-              "dev": true
-            }
           }
         },
         "chownr": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true,
           "optional": true
         },
@@ -4632,6 +4626,44 @@
             "inherits": "^2.0.1",
             "process-nextick-args": "^2.0.0",
             "readable-stream": "^2.3.5"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "code-point-at": {
@@ -4639,26 +4671,6 @@
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
-        },
-        "coinstring": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
-          "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "bs58": "^2.0.1",
-            "create-hash": "^1.1.1"
-          },
-          "dependencies": {
-            "bs58": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
-              "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40=",
-              "dev": true,
-              "optional": true
-            }
-          }
         },
         "collection-map": {
           "version": "1.0.0",
@@ -4697,14 +4709,11 @@
           }
         },
         "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
+          "optional": true
         },
         "component-emitter": {
           "version": "1.3.0",
@@ -4728,6 +4737,44 @@
             "inherits": "^2.0.3",
             "readable-stream": "^2.2.2",
             "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "content-disposition": {
@@ -4753,7 +4800,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "convert-source-map": {
           "version": "1.7.0",
@@ -4790,7 +4838,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
@@ -4838,14 +4887,14 @@
           }
         },
         "create-ecdh": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-          "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+          "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
           "dev": true,
           "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
-            "elliptic": "^6.0.0"
+            "elliptic": "^6.5.3"
           }
         },
         "create-hash": {
@@ -4946,9 +4995,9 @@
           "dev": true
         },
         "decompress": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-          "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+          "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4976,6 +5025,7 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -4985,6 +5035,7 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -5212,7 +5263,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "des.js": {
           "version": "1.0.1",
@@ -5229,7 +5281,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-file": {
           "version": "1.0.0",
@@ -5259,9 +5312,9 @@
           }
         },
         "dom-walk": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-          "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+          "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
           "dev": true
         },
         "dotignore": {
@@ -5288,7 +5341,8 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "duplexify": {
           "version": "3.7.1",
@@ -5300,6 +5354,44 @@
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0",
             "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "each-props": {
@@ -5326,18 +5418,19 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "electron-to-chromium": {
-          "version": "1.3.341",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.341.tgz",
-          "integrity": "sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g==",
+          "version": "1.3.521",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.521.tgz",
+          "integrity": "sha512-7/Cf5jUuAfLRY8SjfRES/6+9BDvmHAB2YQotCAaXK0IEacpjoSlyosPoC4s7lfb7vIOBubXvsssu8+8qaRGjcg==",
           "dev": true
         },
         "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
@@ -5353,15 +5446,27 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "encoding": {
-          "version": "0.1.12",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+          "version": "0.1.13",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+          "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
           "dev": true,
           "requires": {
-            "iconv-lite": "~0.4.13"
+            "iconv-lite": "^0.6.2"
+          },
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+              "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+              "dev": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+              }
+            }
           }
         },
         "encoding-down": {
@@ -5416,22 +5521,22 @@
           }
         },
         "es-abstract": {
-          "version": "1.17.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
             "object-inspect": "^1.7.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
           },
           "dependencies": {
             "object-keys": {
@@ -5501,7 +5606,8 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -5519,7 +5625,8 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -5547,18 +5654,18 @@
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
+                "safe-buffer": "^5.1.1"
               }
             },
             "pify": {
@@ -5671,18 +5778,18 @@
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-vm": {
@@ -5718,30 +5825,18 @@
                   },
                   "dependencies": {
                     "ethereumjs-util": {
-                      "version": "5.2.0",
-                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-                      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+                      "version": "5.2.1",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
+                        "elliptic": "^6.5.2",
+                        "ethereum-cryptography": "^0.1.3",
                         "ethjs-util": "^0.1.3",
-                        "keccak": "^1.0.2",
                         "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1",
-                        "secp256k1": "^3.0.1"
-                      }
-                    },
-                    "keccak": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                      "dev": true,
-                      "requires": {
-                        "bindings": "^1.2.1",
-                        "inherits": "^2.0.3",
-                        "nan": "^2.2.1",
-                        "safe-buffer": "^5.1.0"
+                        "safe-buffer": "^5.1.1"
                       }
                     }
                   }
@@ -5757,39 +5852,21 @@
                   }
                 },
                 "ethereumjs-util": {
-                  "version": "6.2.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-                  "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+                  "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "keccak": "^2.0.0",
-                    "rlp": "^2.2.3",
-                    "secp256k1": "^3.0.1"
-                  }
-                },
-                "keccak": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-                  "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-                  "dev": true,
-                  "requires": {
-                    "bindings": "^1.5.0",
-                    "inherits": "^2.0.4",
-                    "nan": "^2.14.0",
-                    "safe-buffer": "^5.2.0"
+                    "rlp": "^2.2.3"
                   }
                 }
               }
-            },
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
             }
           }
         },
@@ -5843,33 +5920,33 @@
               },
               "dependencies": {
                 "ethereumjs-util": {
-                  "version": "4.5.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-                  "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+                  "version": "4.5.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
+                  "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
                   "dev": true,
                   "requires": {
                     "bn.js": "^4.8.0",
                     "create-hash": "^1.1.2",
-                    "keccakjs": "^0.2.0",
-                    "rlp": "^2.0.0",
-                    "secp256k1": "^3.0.1"
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
+                    "rlp": "^2.0.0"
                   }
                 }
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -5941,18 +6018,18 @@
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-vm": {
@@ -5988,30 +6065,18 @@
                   },
                   "dependencies": {
                     "ethereumjs-util": {
-                      "version": "5.2.0",
-                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-                      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+                      "version": "5.2.1",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
+                        "elliptic": "^6.5.2",
+                        "ethereum-cryptography": "^0.1.3",
                         "ethjs-util": "^0.1.3",
-                        "keccak": "^1.0.2",
                         "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1",
-                        "secp256k1": "^3.0.1"
-                      }
-                    },
-                    "keccak": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                      "dev": true,
-                      "requires": {
-                        "bindings": "^1.2.1",
-                        "inherits": "^2.0.3",
-                        "nan": "^2.2.1",
-                        "safe-buffer": "^5.1.0"
+                        "safe-buffer": "^5.1.1"
                       }
                     }
                   }
@@ -6027,90 +6092,75 @@
                   }
                 },
                 "ethereumjs-util": {
-                  "version": "6.2.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-                  "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+                  "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "keccak": "^2.0.0",
-                    "rlp": "^2.2.3",
-                    "secp256k1": "^3.0.1"
-                  }
-                },
-                "keccak": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-                  "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-                  "dev": true,
-                  "requires": {
-                    "bindings": "^1.5.0",
-                    "inherits": "^2.0.4",
-                    "nan": "^2.14.0",
-                    "safe-buffer": "^5.2.0"
+                    "rlp": "^2.2.3"
                   }
                 }
               }
-            },
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
             }
           }
         },
         "ethashjs": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.7.tgz",
-          "integrity": "sha1-ML/kGWcmaQoMWdO4Jy5w1NDDS64=",
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
+          "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
           "dev": true,
           "requires": {
-            "async": "^1.4.2",
-            "buffer-xor": "^1.0.3",
-            "ethereumjs-util": "^4.0.1",
+            "async": "^2.1.2",
+            "buffer-xor": "^2.0.1",
+            "ethereumjs-util": "^7.0.2",
             "miller-rabin": "^4.0.0"
           },
           "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "bn.js": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+              "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
               "dev": true
             },
-            "ethereumjs-util": {
-              "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-              "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+            "buffer-xor": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+              "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.8.0",
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "ethereumjs-util": {
+              "version": "7.0.4",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.4.tgz",
+              "integrity": "sha512-isldtbCn9fdnhBPxedMNbFkNWVZ8ZdQvKRDSrdflame/AycAPKMer+vEpndpBxYIB3qxN6bd3Gh1YCQW9LDkCQ==",
+              "dev": true,
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^5.1.2",
                 "create-hash": "^1.1.2",
-                "keccakjs": "^0.2.0",
-                "rlp": "^2.0.0",
-                "secp256k1": "^3.0.1"
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "^2.2.4"
               }
             }
           }
         },
         "ethereum-bloom-filters": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
-          "integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
+          "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "js-sha3": "^0.8.0"
-          },
-          "dependencies": {
-            "js-sha3": {
-              "version": "0.8.0",
-              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-              "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-              "dev": true
-            }
           }
         },
         "ethereum-common": {
@@ -6118,6 +6168,29 @@
           "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
           "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
           "dev": true
+        },
+        "ethereum-cryptography": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+          "dev": true,
+          "requires": {
+            "@types/pbkdf2": "^3.0.0",
+            "@types/secp256k1": "^4.0.1",
+            "blakejs": "^1.1.0",
+            "browserify-aes": "^1.2.0",
+            "bs58check": "^2.1.2",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "hash.js": "^1.1.7",
+            "keccak": "^3.0.0",
+            "pbkdf2": "^3.0.17",
+            "randombytes": "^2.1.0",
+            "safe-buffer": "^5.1.2",
+            "scrypt-js": "^3.0.0",
+            "secp256k1": "^4.0.1",
+            "setimmediate": "^1.0.5"
+          }
         },
         "ethereumjs-abi": {
           "version": "0.6.7",
@@ -6154,64 +6227,38 @@
           },
           "dependencies": {
             "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
+                "safe-buffer": "^5.1.1"
               }
             }
           }
         },
         "ethereumjs-blockchain": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.3.tgz",
-          "integrity": "sha512-0nJWbyA+Gu0ZKZr/cywMtB/77aS/4lOVsIKbgUN2sFQYscXO5rPbUfrEe7G2Zhjp86/a0VqLllemDSTHvx3vZA==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
+          "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
           "dev": true,
           "requires": {
             "async": "^2.6.1",
             "ethashjs": "~0.0.7",
             "ethereumjs-block": "~2.2.2",
             "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "~6.1.0",
+            "ethereumjs-util": "^6.1.0",
             "flow-stoplight": "^1.0.0",
             "level-mem": "^3.0.1",
             "lru-cache": "^5.1.1",
             "rlp": "^2.2.2",
             "semaphore": "^1.1.0"
-          },
-          "dependencies": {
-            "ethereumjs-util": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-              "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-              "dev": true,
-              "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "ethjs-util": "0.1.6",
-                "keccak": "^1.0.2",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
-              }
-            },
-            "lru-cache": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-              "dev": true,
-              "requires": {
-                "yallist": "^3.0.2"
-              }
-            }
           }
         },
         "ethereumjs-common": {
@@ -6257,11 +6304,21 @@
                 "safe-buffer": "^5.2.0"
               }
             },
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
+            "secp256k1": {
+              "version": "3.8.0",
+              "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+              "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+              "dev": true,
+              "requires": {
+                "bindings": "^1.5.0",
+                "bip66": "^1.1.5",
+                "bn.js": "^4.11.8",
+                "create-hash": "^1.2.0",
+                "drbg.js": "^1.0.1",
+                "elliptic": "^6.5.2",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.1.2"
+              }
             }
           }
         },
@@ -6311,6 +6368,7 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -6320,7 +6378,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6338,12 +6397,13 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "events": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-          "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+          "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
           "dev": true
         },
         "evp_bytestokey": {
@@ -6617,9 +6677,9 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "fast-json-stable-stringify": {
@@ -6663,7 +6723,8 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -6784,6 +6845,44 @@
           "requires": {
             "inherits": "^2.0.3",
             "readable-stream": "^2.3.6"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "for-each": {
@@ -6847,13 +6946,15 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-extra": {
           "version": "4.0.3",
@@ -6987,12 +7088,50 @@
             "remove-trailing-separator": "^1.0.1",
             "to-absolute-glob": "^2.0.0",
             "unique-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "glob-watcher": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
-          "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
+          "integrity": "sha512-zOZgGGEHPklZNjZQaZ9f41i7F2YwE+tS5ZHrDhbBCk3stwahn5vQxnFmBJZHoYdusR6R1bLSXeGUy/BhctwKzw==",
           "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
@@ -7000,6 +7139,7 @@
             "chokidar": "^2.0.0",
             "is-negated-glob": "^1.0.0",
             "just-debounce": "^1.0.0",
+            "normalize-path": "^3.0.0",
             "object.defaults": "^1.1.0"
           }
         },
@@ -7073,17 +7213,10 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "dev": true,
-          "optional": true
         },
         "gulp": {
           "version": "4.0.2",
@@ -7098,9 +7231,9 @@
           },
           "dependencies": {
             "gulp-cli": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
-              "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+              "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
               "dev": true,
               "requires": {
                 "ansi-colors": "^1.0.1",
@@ -7111,7 +7244,7 @@
                 "copy-props": "^2.0.1",
                 "fancy-log": "^1.3.2",
                 "gulplog": "^1.0.0",
-                "interpret": "^1.1.0",
+                "interpret": "^1.4.0",
                 "isobject": "^3.0.1",
                 "liftoff": "^3.1.0",
                 "matchdep": "^2.0.0",
@@ -7119,7 +7252,7 @@
                 "pretty-hrtime": "^1.0.0",
                 "replace-homedir": "^1.0.0",
                 "semver-greatest-satisfied-range": "^1.1.0",
-                "v8flags": "^3.0.1",
+                "v8flags": "^3.2.0",
                 "yargs": "^7.1.0"
               }
             }
@@ -7141,12 +7274,12 @@
           "dev": true
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "dev": true,
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
           }
         },
@@ -7224,13 +7357,14 @@
           }
         },
         "hash-base": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+          "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
           }
         },
         "hash.js": {
@@ -7244,15 +7378,34 @@
           }
         },
         "hdkey": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.1.tgz",
-          "integrity": "sha512-DvHZ5OuavsfWs5yfVJZestsnc3wzPvLWNk6c2nRUfo6X+OtxypGt20vDDf7Ba+MJzjL3KS1og2nw2eBbLCOUTA==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.2.tgz",
+          "integrity": "sha512-PTQ4VKu0oRnCrYfLp04iQZ7T2Cxz0UsEXYauk2j8eh6PJXCpbXuCFhOmtIFtbET0i3PMWmHN9J11gU8LEgUljQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "coinstring": "^2.0.0",
+            "bs58check": "^2.1.2",
             "safe-buffer": "^5.1.1",
             "secp256k1": "^3.0.1"
+          },
+          "dependencies": {
+            "secp256k1": {
+              "version": "3.8.0",
+              "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+              "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bindings": "^1.5.0",
+                "bip66": "^1.1.5",
+                "bn.js": "^4.11.8",
+                "create-hash": "^1.2.0",
+                "drbg.js": "^1.0.1",
+                "elliptic": "^6.5.2",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.1.2"
+              }
+            }
           }
         },
         "heap": {
@@ -7292,15 +7445,15 @@
           }
         },
         "hosted-git-info": {
-          "version": "2.8.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-          "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "dev": true
         },
         "http-cache-semantics": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-          "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
           "dev": true,
           "optional": true
         },
@@ -7309,6 +7462,7 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -7321,7 +7475,8 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -7329,7 +7484,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -7347,6 +7503,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -7377,9 +7534,9 @@
           "dev": true
         },
         "immediate": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+          "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
           "dev": true
         },
         "inflight": {
@@ -7405,9 +7562,9 @@
           "dev": true
         },
         "interpret": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
           "dev": true
         },
         "invariant": {
@@ -7426,9 +7583,9 @@
           "dev": true
         },
         "ipaddr.js": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+          "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
           "dev": true,
           "optional": true
         },
@@ -7490,9 +7647,9 @@
           "dev": true
         },
         "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
           "dev": true
         },
         "is-data-descriptor": {
@@ -7553,13 +7710,10 @@
           "dev": true
         },
         "is-finite": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+          "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+          "dev": true
         },
         "is-fn": {
           "version": "1.0.0",
@@ -7577,9 +7731,9 @@
           }
         },
         "is-function": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-          "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+          "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
           "dev": true
         },
         "is-glob": {
@@ -7654,12 +7808,12 @@
           }
         },
         "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
           "dev": true,
           "requires": {
-            "has": "^1.0.3"
+            "has-symbols": "^1.0.1"
           }
         },
         "is-relative": {
@@ -7762,10 +7916,11 @@
           }
         },
         "js-sha3": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
-          "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=",
-          "dev": true
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+          "dev": true,
+          "optional": true
         },
         "js-tokens": {
           "version": "3.0.2",
@@ -7895,25 +8050,13 @@
           "dev": true
         },
         "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
           "dev": true,
           "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "keccakjs": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
-          "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
-          "dev": true,
-          "requires": {
-            "browserify-sha3": "^0.0.4",
-            "sha3": "^1.2.2"
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         },
         "keyv": {
@@ -7949,6 +8092,44 @@
           "dev": true,
           "requires": {
             "readable-stream": "^2.0.5"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "lcid": {
@@ -7970,10 +8151,13 @@
           }
         },
         "level-codec": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-          "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
-          "dev": true
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+          "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0"
+          }
         },
         "level-errors": {
           "version": "2.0.1",
@@ -8016,6 +8200,12 @@
                 "isarray": "0.0.1",
                 "string_decoder": "~0.10.x"
               }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
             }
           }
         },
@@ -8037,6 +8227,12 @@
               "requires": {
                 "xtend": "~4.0.0"
               }
+            },
+            "immediate": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+              "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+              "dev": true
             },
             "memdown": {
               "version": "3.0.0",
@@ -8097,6 +8293,12 @@
             "xtend": "~4.0.0"
           },
           "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
             "level-iterator-stream": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
@@ -8113,6 +8315,36 @@
               "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
               "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=",
               "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
             }
           }
         },
@@ -8137,6 +8369,12 @@
                 "isarray": "0.0.1",
                 "string_decoder": "~0.10.x"
               }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
             },
             "xtend": {
               "version": "2.1.2",
@@ -8180,6 +8418,12 @@
                 "inherits": "^2.0.3"
               }
             },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
             "level-iterator-stream": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
@@ -8189,6 +8433,36 @@
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.3.6",
                 "xtend": "^4.0.0"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -8255,7 +8529,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "5.1.1",
@@ -8365,7 +8640,8 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
@@ -8406,19 +8682,25 @@
               "dev": true
             },
             "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
+                "safe-buffer": "^5.1.1"
               }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
             },
             "level-codec": {
               "version": "7.0.1",
@@ -8472,11 +8754,51 @@
                 }
               }
             },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                  "dev": true
+                }
+              }
+            },
             "semver": {
               "version": "5.4.1",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
               "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
               "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                  "dev": true
+                }
+              }
             }
           }
         },
@@ -8522,28 +8844,30 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "version": "2.1.27",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
           "dev": true,
           "requires": {
-            "mime-db": "1.43.0"
+            "mime-db": "1.44.0"
           }
         },
         "mimic-response": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -8576,9 +8900,9 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "minipass": {
@@ -8586,6 +8910,7 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8623,9 +8948,9 @@
           }
         },
         "mkdirp": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true,
           "optional": true
         },
@@ -8640,9 +8965,9 @@
           }
         },
         "mock-fs": {
-          "version": "4.10.4",
-          "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.4.tgz",
-          "integrity": "sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ==",
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
+          "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==",
           "dev": true,
           "optional": true
         },
@@ -8659,9 +8984,9 @@
           "dev": true
         },
         "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
           "dev": true
         },
         "nano-json-stream-parser": {
@@ -8703,10 +9028,22 @@
           "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
           "dev": true
         },
+        "node-addon-api": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+          "dev": true
+        },
         "node-fetch": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+          "dev": true
+        },
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
         },
         "normalize-package-data": {
@@ -8730,13 +9067,10 @@
           }
         },
         "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
         },
         "normalize-url": {
           "version": "4.5.0",
@@ -8765,6 +9099,7 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -8774,7 +9109,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8822,16 +9158,20 @@
           }
         },
         "object-inspect": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
           "dev": true
         },
         "object-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-          "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-          "dev": true
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+          "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5"
+          }
         },
         "object-keys": {
           "version": "0.4.0",
@@ -8924,6 +9264,7 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -8933,6 +9274,7 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -8953,6 +9295,44 @@
           "dev": true,
           "requires": {
             "readable-stream": "^2.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "os-homedir": {
@@ -9005,6 +9385,7 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
           "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "asn1.js": "^4.0.0",
             "browserify-aes": "^1.0.0",
@@ -9056,7 +9437,8 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -9133,9 +9515,9 @@
           }
         },
         "pbkdf2": {
-          "version": "3.0.17",
-          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-          "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+          "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
           "dev": true,
           "requires": {
             "create-hash": "^1.1.2",
@@ -9227,14 +9609,14 @@
           }
         },
         "proxy-addr": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-          "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+          "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
           "dev": true,
           "optional": true,
           "requires": {
             "forwarded": "~0.1.2",
-            "ipaddr.js": "1.9.0"
+            "ipaddr.js": "1.9.1"
           }
         },
         "prr": {
@@ -9250,9 +9632,9 @@
           "dev": true
         },
         "psl": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-          "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+          "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
           "dev": true
         },
         "public-encrypt": {
@@ -9333,6 +9715,7 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
+          "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -9371,13 +9754,15 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -9408,13 +9793,15 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -9444,18 +9831,25 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           },
           "dependencies": {
             "isarray": {
@@ -9463,6 +9857,21 @@
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
             },
             "safe-buffer": {
               "version": "5.1.2",
@@ -9481,17 +9890,6 @@
             }
           }
         },
-        "readdirp": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
-            "readable-stream": "^2.0.2"
-          }
-        },
         "rechoir": {
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -9502,9 +9900,9 @@
           }
         },
         "regenerate": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+          "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -9619,9 +10017,9 @@
           }
         },
         "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+          "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
           "dev": true
         },
         "replace-homedir": {
@@ -9636,9 +10034,9 @@
           }
         },
         "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -9648,7 +10046,7 @@
             "extend": "~3.0.2",
             "forever-agent": "~0.6.1",
             "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
+            "har-validator": "~5.1.3",
             "http-signature": "~1.2.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
@@ -9658,7 +10056,7 @@
             "performance-now": "^2.1.0",
             "qs": "~6.5.2",
             "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
+            "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
           },
@@ -9684,9 +10082,9 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-          "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -9762,9 +10160,9 @@
           }
         },
         "rlp": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
-          "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+          "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.1"
@@ -9777,9 +10175,9 @@
           "dev": true
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         },
         "safe-event-emitter": {
@@ -9807,9 +10205,9 @@
           "dev": true
         },
         "scrypt-js": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
           "dev": true
         },
         "scrypt.js": {
@@ -9819,7 +10217,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "scrypt": "^6.0.2",
             "scryptsy": "^1.2.1"
           }
         },
@@ -9834,27 +10231,14 @@
           }
         },
         "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "dev": true,
           "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
             "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          },
-          "dependencies": {
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
-            }
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         },
         "seedrandom": {
@@ -9864,13 +10248,13 @@
           "dev": true
         },
         "seek-bzip": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-          "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+          "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "commander": "~2.8.1"
+            "commander": "^2.8.1"
           }
         },
         "semaphore": {
@@ -9893,6 +10277,7 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -9914,6 +10299,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -9922,7 +10308,8 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -9930,7 +10317,8 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10000,14 +10388,14 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
           "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "setprototypeof": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -10019,26 +10407,19 @@
             "safe-buffer": "^5.0.1"
           }
         },
-        "sha3": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
-          "integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
-          "dev": true,
-          "requires": {
-            "nan": "2.13.2"
-          }
-        },
         "simple-concat": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "dev": true
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+          "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+          "dev": true,
+          "optional": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -10221,9 +10602,9 @@
           "dev": true
         },
         "spdx-correct": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-          "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+          "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -10231,15 +10612,15 @@
           }
         },
         "spdx-exceptions": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-          "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+          "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
           "dev": true
         },
         "spdx-expression-parse": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -10317,7 +10698,8 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "stream-exhaust": {
           "version": "1.0.2",
@@ -10353,7 +10735,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -10377,31 +10760,34 @@
             "function-bind": "^1.1.1"
           }
         },
-        "string.prototype.trimleft": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+        "string.prototype.trimend": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+          "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
+            "es-abstract": "^1.17.5"
           }
         },
-        "string.prototype.trimright": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+        "string.prototype.trimstart": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+          "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
-            "function-bind": "^1.1.1"
+            "es-abstract": "^1.17.5"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -10534,9 +10920,9 @@
           }
         },
         "tape": {
-          "version": "4.13.0",
-          "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
-          "integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
+          "version": "4.13.3",
+          "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
+          "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
           "dev": true,
           "requires": {
             "deep-equal": "~1.1.1",
@@ -10548,18 +10934,27 @@
             "has": "~1.0.3",
             "inherits": "~2.0.4",
             "is-regex": "~1.0.5",
-            "minimist": "~1.2.0",
+            "minimist": "~1.2.5",
             "object-inspect": "~1.7.0",
-            "resolve": "~1.14.2",
+            "resolve": "~1.17.0",
             "resumer": "~0.0.0",
             "string.prototype.trim": "~1.2.1",
             "through": "~2.3.8"
           },
           "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "is-regex": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+              "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+              "dev": true,
+              "requires": {
+                "has": "^1.0.3"
+              }
+            },
+            "object-inspect": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+              "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
               "dev": true
             }
           }
@@ -10581,13 +10976,13 @@
           },
           "dependencies": {
             "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "version": "0.5.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
               "dev": true,
               "optional": true,
               "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
               }
             }
           }
@@ -10597,6 +10992,7 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -10605,6 +11001,47 @@
             "readable-stream": "^2.3.0",
             "to-buffer": "^1.1.1",
             "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true,
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "through": {
@@ -10621,6 +11058,44 @@
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "through2-filter": {
@@ -10643,7 +11118,8 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tmp": {
           "version": "0.1.0",
@@ -10668,7 +11144,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -10738,24 +11215,17 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "dev": true,
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-              "dev": true
-            }
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
           }
         },
         "trim-right": {
@@ -10774,15 +11244,15 @@
           }
         },
         "tweetnacl": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.2.tgz",
-          "integrity": "sha512-+8aPRjmXgf1VqvyxSlBUzKzeYqVS9Ai8vZ28g+mL7dNQl1jlUTCMDZnvNQdAS1xTywMkIXwJsfipsR/6s2+syw==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
           "dev": true
         },
         "tweetnacl-util": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz",
-          "integrity": "sha1-RXbBzuXi1j0gf+5S8boCgZSAvHU=",
+          "version": "0.15.1",
+          "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+          "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
           "dev": true
         },
         "type": {
@@ -10796,6 +11266,7 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
@@ -10845,9 +11316,9 @@
           "optional": true
         },
         "unbzip2-stream": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-          "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+          "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10865,7 +11336,8 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "undertaker": {
           "version": "1.2.1",
@@ -10929,7 +11401,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -11012,7 +11485,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "url-to-options": {
           "version": "1.0.1",
@@ -11031,7 +11505,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -11065,9 +11540,9 @@
           "dev": true
         },
         "v8flags": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
-          "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+          "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
           "dev": true,
           "requires": {
             "homedir-polyfill": "^1.0.1"
@@ -11093,7 +11568,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "verror": {
           "version": "1.10.0",
@@ -11143,6 +11619,44 @@
             "value-or-function": "^3.0.0",
             "vinyl": "^2.0.0",
             "vinyl-sourcemap": "^1.1.0"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "vinyl-sourcemap": {
@@ -11158,6 +11672,17 @@
             "now-and-later": "^2.0.0",
             "remove-bom-buffer": "^3.0.0",
             "vinyl": "^2.0.0"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
           }
         },
         "web3": {
@@ -11178,9 +11703,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "12.12.26",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
+              "version": "12.12.53",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+              "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ==",
               "dev": true,
               "optional": true
             }
@@ -11200,9 +11725,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.14",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-              "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
+              "version": "10.17.28",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+              "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
               "dev": true,
               "optional": true
             }
@@ -11213,6 +11738,7 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
           "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/bignumber.js": "^5.0.0",
             "@types/bn.js": "^4.11.4",
@@ -11224,10 +11750,11 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "12.12.26",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
-              "dev": true
+              "version": "12.12.53",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+              "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -11236,6 +11763,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
           "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.4",
@@ -11247,6 +11775,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
           "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -11260,6 +11789,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
           "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -11270,6 +11800,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
           "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -11283,6 +11814,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
           "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -11316,6 +11848,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
           "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -11323,22 +11856,25 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.14",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-              "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
-              "dev": true
+              "version": "10.17.28",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+              "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+              "dev": true,
+              "optional": true
             },
             "aes-js": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
               "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "elliptic": {
               "version": "6.3.3",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
               "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -11351,6 +11887,7 @@
               "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
               "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "@types/node": "^10.3.2",
                 "aes-js": "3.0.0",
@@ -11369,6 +11906,7 @@
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
               "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.0"
@@ -11378,19 +11916,29 @@
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
               "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-              "dev": true
+              "dev": true,
+              "optional": true
+            },
+            "scrypt-js": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+              "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+              "dev": true,
+              "optional": true
             },
             "setimmediate": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
               "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "uuid": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
               "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -11441,6 +11989,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
           "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.4",
             "underscore": "1.9.1",
@@ -11475,9 +12024,19 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
           "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "web3-eth-personal": {
@@ -11485,6 +12044,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
           "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "^12.6.1",
             "web3-core": "1.2.4",
@@ -11495,10 +12055,11 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "12.12.26",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
-              "dev": true
+              "version": "12.12.53",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+              "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -11507,6 +12068,7 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
           "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -11567,18 +12129,18 @@
               },
               "dependencies": {
                 "ethereumjs-util": {
-                  "version": "6.2.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-                  "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+                  "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "keccak": "^2.0.0",
-                    "rlp": "^2.2.3",
-                    "secp256k1": "^3.0.1"
+                    "rlp": "^2.2.3"
                   }
                 }
               }
@@ -11626,32 +12188,18 @@
               }
             },
             "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
-              },
-              "dependencies": {
-                "keccak": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                  "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                  "dev": true,
-                  "requires": {
-                    "bindings": "^1.2.1",
-                    "inherits": "^2.0.3",
-                    "nan": "^2.2.1",
-                    "safe-buffer": "^5.1.0"
-                  }
-                }
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-vm": {
@@ -11687,30 +12235,18 @@
                   },
                   "dependencies": {
                     "ethereumjs-util": {
-                      "version": "5.2.0",
-                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-                      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+                      "version": "5.2.1",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
+                        "elliptic": "^6.5.2",
+                        "ethereum-cryptography": "^0.1.3",
                         "ethjs-util": "^0.1.3",
-                        "keccak": "^1.0.2",
                         "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1",
-                        "secp256k1": "^3.0.1"
-                      }
-                    },
-                    "keccak": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                      "dev": true,
-                      "requires": {
-                        "bindings": "^1.2.1",
-                        "inherits": "^2.0.3",
-                        "nan": "^2.2.1",
-                        "safe-buffer": "^5.1.0"
+                        "safe-buffer": "^5.1.1"
                       }
                     }
                   }
@@ -11726,39 +12262,67 @@
                   }
                 },
                 "ethereumjs-util": {
-                  "version": "6.2.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-                  "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+                  "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "keccak": "^2.0.0",
-                    "rlp": "^2.2.3",
-                    "secp256k1": "^3.0.1"
+                    "rlp": "^2.2.3"
                   }
                 }
               }
             },
-            "keccak": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-              "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "bindings": "^1.5.0",
-                "inherits": "^2.0.4",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.2.0"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                  "dev": true
+                }
               }
             },
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                  "dev": true
+                }
+              }
             },
             "ws": {
               "version": "5.2.2",
@@ -11776,6 +12340,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
           "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.4",
             "xhr2-cookies": "1.1.0"
@@ -11786,6 +12351,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
           "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
           "dev": true,
+          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -11797,6 +12363,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
           "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@web3-js/websocket": "^1.0.29",
             "underscore": "1.9.1",
@@ -11821,6 +12388,7 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
           "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -11832,11 +12400,19 @@
             "utf8": "3.0.0"
           },
           "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true,
+              "optional": true
+            },
             "eth-lib": {
               "version": "0.2.7",
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
@@ -11950,6 +12526,7 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -11961,12 +12538,13 @@
           }
         },
         "xhr-request-promise": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
-          "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+          "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "xhr-request": "^1.0.1"
+            "xhr-request": "^1.1.0"
           }
         },
         "xhr2-cookies": {
@@ -11974,6 +12552,7 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
@@ -11982,7 +12561,8 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
           "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "xtend": {
           "version": "4.0.2",
@@ -12009,9 +12589,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+          "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
           "dev": true,
           "requires": {
             "camelcase": "^3.0.0",
@@ -12026,16 +12606,17 @@
             "string-width": "^1.0.2",
             "which-module": "^1.0.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "yargs-parser": "5.0.0-security.0"
           }
         },
         "yargs-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "version": "5.0.0-security.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+          "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "^3.0.0",
+            "object.assign": "^4.1.0"
           }
         },
         "yauzl": {
@@ -12090,6 +12671,27 @@
         "traverse": "~0.6.6"
       },
       "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "split2": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
@@ -12097,6 +12699,25 @@
           "dev": true,
           "requires": {
             "through2": "~2.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -12116,24 +12737,12 @@
       }
     },
     "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
+        "is-glob": "^4.0.1"
       }
     },
     "global-modules-path": {
@@ -12157,9 +12766,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "handlebars": {
@@ -12173,14 +12782,6 @@
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "hard-rejection": {
@@ -12216,6 +12817,26 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -12228,12 +12849,13 @@
       }
     },
     "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       }
     },
     "hash.js": {
@@ -12262,12 +12884,12 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
-      "integrity": "sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
+      "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^5.1.1"
+        "lru-cache": "^6.0.0"
       }
     },
     "http-proxy-agent": {
@@ -12279,23 +12901,6 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "https-browserify": {
@@ -12312,23 +12917,6 @@
       "requires": {
         "agent-base": "6",
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "human-signals": {
@@ -12389,14 +12977,6 @@
       "dev": true,
       "requires": {
         "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        }
       }
     },
     "import-local": {
@@ -12503,9 +13083,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
-      "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -12514,7 +13094,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.12",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
@@ -12523,11 +13103,26 @@
         "through": "^2.3.6"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -12553,9 +13148,9 @@
       }
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "into-stream": {
@@ -12608,12 +13203,13 @@
       "dev": true
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-buffer": {
@@ -12693,24 +13289,10 @@
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
     "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
@@ -12725,18 +13307,9 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "requires": {
-        "isobject": "^3.0.1"
-      }
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+      "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
       "dev": true
     },
     "is-stream": {
@@ -12911,12 +13484,6 @@
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
           }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
         }
       }
     },
@@ -12927,13 +13494,13 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
+        "emojis-list": "^3.0.0",
         "json5": "^1.0.1"
       }
     },
@@ -12947,9 +13514,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.capitalize": {
@@ -12995,18 +13562,18 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
       }
     },
     "macos-release": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
+      "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
       "dev": true
     },
     "make-dir": {
@@ -13017,6 +13584,14 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "map-age-cleaner": {
@@ -13049,9 +13624,9 @@
       }
     },
     "marked": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
-      "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
+      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==",
       "dev": true
     },
     "marked-terminal": {
@@ -13068,15 +13643,6 @@
         "supports-hyperlinks": "^2.1.0"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.11.0"
-          }
-        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -13126,12 +13692,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
         }
       }
     },
@@ -13163,6 +13723,38 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "meow": {
@@ -13225,24 +13817,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
       }
     },
     "miller-rabin": {
@@ -13292,9 +13873,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "minimist-options": {
@@ -13332,6 +13913,48 @@
         "pumpify": "^1.3.3",
         "stream-each": "^1.1.0",
         "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "mixin-deep": {
@@ -13352,6 +13975,15 @@
           "requires": {
             "is-plain-object": "^2.0.4"
           }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
         }
       }
     },
@@ -13362,14 +13994,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "modify-values": {
@@ -13393,9 +14017,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "mute-stream": {
@@ -13405,9 +14029,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13429,9 +14053,9 @@
       }
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "nerf-dart": {
@@ -13496,6 +14120,38 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -13532,9 +14188,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.0.0.tgz",
-      "integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.1.0.tgz",
+      "integrity": "sha512-UxHuSWsSAmzSqN+DSjasaZWQ3QPtEisHdlr4y9MJ5zg0RcImv5fQt8QM0izJSCdsdmhJGK+ubcTpJXwVDmwSVQ==",
       "dev": true
     },
     "notp": {
@@ -13544,9 +14200,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.14.5",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.5.tgz",
-      "integrity": "sha512-CDwa3FJd0XJpKDbWCST484H+mCNjF26dPrU+xnREW+upR0UODjMEfXPl3bxWuAwZIX6c2ASg1plLO7jP8ehWeA==",
+      "version": "6.14.7",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.7.tgz",
+      "integrity": "sha512-swhsdpNpyXg4GbM6LpOQ6qaloQuIKizZ+Zh6JPXJQc59ka49100Js0WvZx594iaKSoFgkFq2s8uXFHS3/Xy2WQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -13555,7 +14211,7 @@
         "ansistyles": "~0.1.3",
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.7",
+        "bin-links": "^1.1.8",
         "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
         "cacache": "^12.0.3",
@@ -13576,7 +14232,7 @@
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.3.0",
+        "gentle-fs": "^2.3.1",
         "glob": "^7.1.6",
         "graceful-fs": "^4.2.4",
         "has-unicode": "~2.0.1",
@@ -13591,14 +14247,14 @@
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.7",
+        "libcipm": "^4.0.8",
         "libnpm": "^3.0.1",
         "libnpmaccess": "^3.0.2",
         "libnpmhook": "^5.0.3",
         "libnpmorg": "^1.0.1",
         "libnpmsearch": "^2.0.2",
         "libnpmteam": "^1.0.2",
-        "libnpx": "^10.2.2",
+        "libnpx": "^10.2.4",
         "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
@@ -13620,15 +14276,15 @@
         "node-gyp": "^5.1.0",
         "nopt": "^4.0.3",
         "normalize-package-data": "^2.5.0",
-        "npm-audit-report": "^1.3.2",
+        "npm-audit-report": "^1.3.3",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "^3.0.2",
-        "npm-lifecycle": "^3.1.4",
+        "npm-lifecycle": "^3.1.5",
         "npm-package-arg": "^6.1.1",
         "npm-packlist": "^1.4.8",
         "npm-pick-manifest": "^3.0.2",
         "npm-profile": "^4.0.4",
-        "npm-registry-fetch": "^4.0.4",
+        "npm-registry-fetch": "^4.0.5",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
@@ -13676,7 +14332,8 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+          "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
           "dev": true,
           "requires": {
             "jsonparse": "^1.2.0",
@@ -13685,12 +14342,14 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "agent-base": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
           "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
@@ -13698,7 +14357,8 @@
         },
         "agentkeepalive": {
           "version": "3.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+          "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "dev": true,
           "requires": {
             "humanize-ms": "^1.2.1"
@@ -13706,7 +14366,8 @@
         },
         "ajv": {
           "version": "5.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
             "co": "^4.6.0",
@@ -13717,7 +14378,8 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
             "string-width": "^2.0.0"
@@ -13725,12 +14387,14 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -13738,27 +14402,32 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "dev": true
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -13767,7 +14436,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -13781,7 +14451,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -13791,12 +14462,14 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -13804,32 +14477,38 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -13837,8 +14516,9 @@
           }
         },
         "bin-links": {
-          "version": "1.1.7",
-          "bundled": true,
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
+          "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -13851,12 +14531,14 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
@@ -13870,7 +14552,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -13879,27 +14562,32 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
           "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "dev": true
         },
         "byline": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+          "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
           "dev": true
         },
         "byte-size": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
+          "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
           "dev": true
         },
         "cacache": {
           "version": "12.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -13921,27 +14609,32 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
+          "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -13951,17 +14644,20 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "dev": true
         },
         "cidr-regex": {
           "version": "2.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
+          "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
           "dev": true,
           "requires": {
             "ip-regex": "^2.1.0"
@@ -13969,12 +14665,14 @@
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "dev": true,
           "requires": {
             "string-width": "^2.0.0",
@@ -13983,7 +14681,8 @@
         },
         "cli-table3": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+          "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
           "dev": true,
           "requires": {
             "colors": "^1.1.2",
@@ -13992,38 +14691,60 @@
           }
         },
         "cliui": {
-          "version": "4.1.0",
-          "bundled": true,
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "dev": true
             },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
               }
             }
           }
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "dev": true
         },
         "cmd-shim": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
+          "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14032,17 +14753,20 @@
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "dev": true,
           "requires": {
             "color-name": "^1.1.1"
@@ -14050,18 +14774,21 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "colors": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
           "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -14070,7 +14797,8 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -14078,12 +14806,14 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -14094,7 +14824,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -14108,7 +14839,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -14118,7 +14850,8 @@
         },
         "config-chain": {
           "version": "1.1.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+          "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
           "dev": true,
           "requires": {
             "ini": "^1.3.4",
@@ -14127,7 +14860,8 @@
         },
         "configstore": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "dev": true,
           "requires": {
             "dot-prop": "^4.1.0",
@@ -14140,12 +14874,14 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -14158,24 +14894,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
@@ -14183,7 +14923,8 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -14193,7 +14934,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
@@ -14202,24 +14944,28 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "dev": true
             }
           }
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -14227,7 +14973,8 @@
         },
         "debug": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -14235,34 +14982,40 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
@@ -14270,7 +15023,8 @@
         },
         "define-properties": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
@@ -14278,27 +15032,32 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -14307,7 +15066,8 @@
         },
         "dot-prop": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -14315,17 +15075,20 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "dev": true
         },
         "duplexify": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+          "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.0.0",
@@ -14336,7 +15099,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -14350,7 +15114,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -14360,7 +15125,8 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -14370,12 +15136,20 @@
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "encoding": {
           "version": "0.1.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "dev": true,
           "requires": {
             "iconv-lite": "~0.4.13"
@@ -14383,7 +15157,8 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -14391,17 +15166,20 @@
         },
         "env-paths": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
           "dev": true
         },
         "err-code": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
           "dev": true
         },
         "errno": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "dev": true,
           "requires": {
             "prr": "~1.0.1"
@@ -14409,7 +15187,8 @@
         },
         "es-abstract": {
           "version": "1.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+          "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.1.1",
@@ -14421,7 +15200,8 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
           "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
@@ -14431,12 +15211,14 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
           "dev": true
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "dev": true,
           "requires": {
             "es6-promise": "^4.0.3"
@@ -14444,12 +15226,14 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -14463,52 +15247,52 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
           "dev": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
           "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
           "dev": true
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+          "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -14517,7 +15301,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -14531,7 +15316,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -14541,12 +15327,14 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true
         },
         "form-data": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -14556,7 +15344,8 @@
         },
         "from2": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -14565,7 +15354,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -14579,7 +15369,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -14589,7 +15380,8 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "requires": {
             "minipass": "^2.6.0"
@@ -14597,7 +15389,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -14608,7 +15401,8 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14618,7 +15412,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14629,12 +15424,14 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -14648,7 +15445,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -14658,17 +15456,20 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "dev": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -14683,12 +15484,14 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -14700,12 +15503,14 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+          "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
           "dev": true
         },
         "gentle-fs": {
-          "version": "2.3.0",
-          "bundled": true,
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
+          "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.2",
@@ -14723,24 +15528,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
           }
         },
         "get-caller-file": {
-          "version": "1.0.3",
-          "bundled": true,
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -14748,7 +15557,8 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -14756,7 +15566,8 @@
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -14769,7 +15580,8 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
             "ini": "^1.3.4"
@@ -14777,7 +15589,8 @@
         },
         "got": {
           "version": "6.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
@@ -14795,24 +15608,28 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
           "dev": true
         },
         "har-validator": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
           "dev": true,
           "requires": {
             "ajv": "^5.3.0",
@@ -14821,7 +15638,8 @@
         },
         "has": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
@@ -14829,32 +15647,38 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "has-symbols": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "dev": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
           "dev": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "dev": true,
           "requires": {
             "agent-base": "4",
@@ -14863,7 +15687,8 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -14873,7 +15698,8 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
           "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
@@ -14882,7 +15708,8 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "dev": true,
           "requires": {
             "ms": "^2.0.0"
@@ -14890,7 +15717,8 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -14898,12 +15726,14 @@
         },
         "iferr": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+          "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
           "dev": true
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -14911,22 +15741,26 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -14935,17 +15769,20 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -14958,29 +15795,28 @@
             "validate-npm-package-name": "^3.0.0"
           }
         },
-        "invert-kv": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "ip": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
           "dev": true
         },
         "is-callable": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
           "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
             "ci-info": "^1.5.0"
@@ -14988,14 +15824,16 @@
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+              "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
               "dev": true
             }
           }
         },
         "is-cidr": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
+          "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
           "dev": true,
           "requires": {
             "cidr-regex": "^2.0.10"
@@ -15003,12 +15841,14 @@
         },
         "is-date-object": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -15016,7 +15856,8 @@
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
@@ -15025,17 +15866,20 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -15043,12 +15887,14 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "dev": true,
           "requires": {
             "has": "^1.0.1"
@@ -15056,17 +15902,20 @@
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-symbol": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
           "dev": true,
           "requires": {
             "has-symbols": "^1.0.0"
@@ -15074,58 +15923,69 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -15136,7 +15996,8 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "requires": {
             "package-json": "^4.0.0"
@@ -15144,20 +16005,14 @@
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "dev": true
         },
-        "lcid": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^2.0.0"
-          }
-        },
         "libcipm": {
-          "version": "4.0.7",
-          "bundled": true,
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
+          "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
           "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -15166,7 +16021,7 @@
             "find-npm-prefix": "^1.0.2",
             "graceful-fs": "^4.1.11",
             "ini": "^1.3.5",
-            "lock-verify": "^2.0.2",
+            "lock-verify": "^2.1.0",
             "mkdirp": "^0.5.1",
             "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
@@ -15179,7 +16034,8 @@
         },
         "libnpm": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
+          "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
           "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -15206,7 +16062,8 @@
         },
         "libnpmaccess": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
+          "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -15217,7 +16074,8 @@
         },
         "libnpmconfig": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+          "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -15227,7 +16085,8 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "dev": true,
               "requires": {
                 "locate-path": "^3.0.0"
@@ -15235,7 +16094,8 @@
             },
             "locate-path": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "dev": true,
               "requires": {
                 "p-locate": "^3.0.0",
@@ -15244,7 +16104,8 @@
             },
             "p-limit": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+              "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
               "dev": true,
               "requires": {
                 "p-try": "^2.0.0"
@@ -15252,7 +16113,8 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "dev": true,
               "requires": {
                 "p-limit": "^2.0.0"
@@ -15260,14 +16122,16 @@
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "dev": true
             }
           }
         },
         "libnpmhook": {
           "version": "5.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
+          "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -15278,7 +16142,8 @@
         },
         "libnpmorg": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
+          "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -15289,7 +16154,8 @@
         },
         "libnpmpublish": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
+          "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -15305,7 +16171,8 @@
         },
         "libnpmsearch": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
+          "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -15315,7 +16182,8 @@
         },
         "libnpmteam": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
+          "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -15325,8 +16193,9 @@
           }
         },
         "libnpx": {
-          "version": "10.2.2",
-          "bundled": true,
+          "version": "10.2.4",
+          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
+          "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
           "dev": true,
           "requires": {
             "dotenv": "^5.0.1",
@@ -15336,21 +16205,13 @@
             "update-notifier": "^2.3.0",
             "which": "^1.3.0",
             "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "yargs": "^14.2.3"
           }
         },
         "lock-verify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
+          "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
           "dev": true,
           "requires": {
             "npm-package-arg": "^6.1.0",
@@ -15359,7 +16220,8 @@
         },
         "lockfile": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+          "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
           "dev": true,
           "requires": {
             "signal-exit": "^3.0.2"
@@ -15367,12 +16229,14 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
           "requires": {
             "lodash._createset": "~4.0.0",
@@ -15381,17 +16245,20 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
@@ -15399,52 +16266,62 @@
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+          "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
           "dev": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
             "yallist": "^3.0.2"
@@ -15452,7 +16329,8 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
@@ -15460,7 +16338,8 @@
         },
         "make-fetch-happen": {
           "version": "5.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
+          "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
           "dev": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
@@ -15476,44 +16355,22 @@
             "ssri": "^6.0.0"
           }
         },
-        "map-age-cleaner": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-defer": "^1.0.0"
-          }
-        },
         "meant": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
+          "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
           "dev": true
-        },
-        "mem": {
-          "version": "4.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
-            "p-is-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "mimic-fn": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
         },
         "mime-db": {
           "version": "1.35.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.19",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
           "dev": true,
           "requires": {
             "mime-db": "~1.35.0"
@@ -15521,7 +16378,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -15529,7 +16387,8 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "requires": {
             "minipass": "^2.9.0"
@@ -15537,7 +16396,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -15548,7 +16408,8 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "dev": true,
           "requires": {
             "concat-stream": "^1.5.0",
@@ -15565,7 +16426,8 @@
         },
         "mkdirp": {
           "version": "0.5.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -15573,14 +16435,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -15593,29 +16457,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "nice-try": {
-          "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+          "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "dev": true,
           "requires": {
             "encoding": "^0.1.11",
@@ -15625,7 +16488,8 @@
         },
         "node-gyp": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
+          "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
@@ -15643,7 +16507,8 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "dev": true,
           "requires": {
             "abbrev": "1",
@@ -15652,7 +16517,8 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -15663,7 +16529,8 @@
           "dependencies": {
             "resolve": {
               "version": "1.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "dev": true,
               "requires": {
                 "path-parse": "^1.0.6"
@@ -15672,8 +16539,9 @@
           }
         },
         "npm-audit-report": {
-          "version": "1.3.2",
-          "bundled": true,
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
+          "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
           "dev": true,
           "requires": {
             "cli-table3": "^0.5.0",
@@ -15682,7 +16550,8 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
@@ -15690,20 +16559,23 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.2.tgz",
+          "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
           "dev": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
-          "version": "3.1.4",
-          "bundled": true,
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
+          "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
           "dev": true,
           "requires": {
             "byline": "^5.0.0",
@@ -15718,17 +16590,20 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+          "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
           "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.7.1",
@@ -15739,7 +16614,8 @@
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -15749,7 +16625,8 @@
         },
         "npm-pick-manifest": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
+          "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -15759,7 +16636,8 @@
         },
         "npm-profile": {
           "version": "4.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
+          "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
@@ -15768,8 +16646,9 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.4",
-          "bundled": true,
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.5.tgz",
+          "integrity": "sha512-yQ0/U4fYpCCqmueB2g8sc+89ckQ3eXpmU4+Yi2j5o/r0WkKvE2+Y0tK3DEILAtn2UaQTkjTHxIXe2/CSdit+/Q==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.3.4",
@@ -15782,15 +16661,17 @@
           },
           "dependencies": {
             "safe-buffer": {
-              "version": "5.2.0",
-              "bundled": true,
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
               "dev": true
             }
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -15798,12 +16679,14 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -15814,27 +16697,32 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object-keys": {
           "version": "1.0.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
           "dev": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+          "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
@@ -15843,7 +16731,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -15851,105 +16740,42 @@
         },
         "opener": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
-        },
-        "os-locale": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^1.0.0",
-            "lcid": "^2.0.0",
-            "mem": "^4.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "6.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "execa": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-              }
-            }
-          }
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
           }
         },
-        "p-defer": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-is-promise": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "requires": {
             "got": "^6.7.1",
@@ -15960,7 +16786,8 @@
         },
         "pacote": {
           "version": "9.5.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
+          "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -15997,7 +16824,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -16008,7 +16836,8 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+          "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "dev": true,
           "requires": {
             "cyclist": "~0.2.2",
@@ -16018,7 +16847,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -16032,7 +16862,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -16042,57 +16873,68 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "dev": true
         },
         "promise-retry": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+          "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "dev": true,
           "requires": {
             "err-code": "^1.0.0",
@@ -16101,14 +16943,16 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "dev": true
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "dev": true,
           "requires": {
             "read": "1"
@@ -16116,12 +16960,14 @@
         },
         "proto-list": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
           "dev": true
         },
         "protoduck": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+          "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "dev": true,
           "requires": {
             "genfun": "^5.0.0"
@@ -16129,22 +16975,26 @@
         },
         "prr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "psl": {
           "version": "1.1.29",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+          "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -16153,7 +17003,8 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "dev": true,
           "requires": {
             "duplexify": "^3.6.0",
@@ -16163,7 +17014,8 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -16174,22 +17026,26 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         },
         "query-string": {
           "version": "6.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -16199,12 +17055,14 @@
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
           "dev": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -16215,14 +17073,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
           }
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -16230,7 +17090,8 @@
         },
         "read-cmd-shim": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
+          "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -16238,7 +17099,8 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -16252,7 +17114,8 @@
         },
         "read-package-json": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
+          "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -16264,7 +17127,8 @@
         },
         "read-package-tree": {
           "version": "5.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
           "dev": true,
           "requires": {
             "read-package-json": "^2.0.0",
@@ -16274,7 +17138,8 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -16284,7 +17149,8 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+          "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -16295,7 +17161,8 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "dev": true,
           "requires": {
             "rc": "^1.1.6",
@@ -16304,7 +17171,8 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "requires": {
             "rc": "^1.0.1"
@@ -16312,7 +17180,8 @@
         },
         "request": {
           "version": "2.88.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -16339,27 +17208,32 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -16367,7 +17241,8 @@
         },
         "run-queue": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1"
@@ -16375,29 +17250,34 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "requires": {
             "semver": "^5.0.3"
@@ -16405,12 +17285,14 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "sha": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
+          "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -16418,7 +17300,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -16426,27 +17309,32 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+          "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
           "dev": true
         },
         "socks": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+          "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
           "dev": true,
           "requires": {
             "ip": "1.1.5",
@@ -16455,7 +17343,8 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+          "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
           "dev": true,
           "requires": {
             "agent-base": "~4.2.1",
@@ -16464,7 +17353,8 @@
           "dependencies": {
             "agent-base": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+              "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
               "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
@@ -16474,12 +17364,14 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "dev": true,
           "requires": {
             "from2": "^1.3.0",
@@ -16488,7 +17380,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
@@ -16497,12 +17390,14 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
               "dev": true
             },
             "readable-stream": {
               "version": "1.1.14",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -16513,14 +17408,16 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -16529,12 +17426,14 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -16542,18 +17441,21 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.3",
-          "bundled": true,
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
           "dev": true
         },
         "split-on-first": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
           "dev": true
         },
         "sshpk": {
           "version": "1.14.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "dev": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -16569,7 +17471,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -16577,7 +17480,8 @@
         },
         "stream-each": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+          "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -16586,7 +17490,8 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+          "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
           "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
@@ -16595,7 +17500,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -16609,7 +17515,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -16619,17 +17526,20 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
           "dev": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -16638,17 +17548,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -16658,7 +17571,8 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -16666,19 +17580,22 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "dev": true
             }
           }
         },
         "stringify-package": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
+          "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -16686,17 +17603,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -16704,7 +17624,8 @@
         },
         "tar": {
           "version": "4.4.13",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -16718,7 +17639,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -16729,7 +17651,8 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "requires": {
             "execa": "^0.7.0"
@@ -16737,17 +17660,20 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
           "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
@@ -16756,7 +17682,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -16770,7 +17697,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -16780,17 +17708,20 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
+          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
             "psl": "^1.1.24",
@@ -16799,7 +17730,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -16807,28 +17739,33 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "unique-filename": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "dev": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -16836,7 +17773,8 @@
         },
         "unique-slug": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -16844,7 +17782,8 @@
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -16852,17 +17791,20 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "dev": true,
           "requires": {
             "boxen": "^1.2.1",
@@ -16879,7 +17821,8 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
@@ -16887,17 +17830,20 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+          "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
           "dev": true
         },
         "util-promisify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+          "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
           "dev": true,
           "requires": {
             "object.getownpropertydescriptors": "^2.0.3"
@@ -16905,12 +17851,14 @@
         },
         "uuid": {
           "version": "3.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -16919,7 +17867,8 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
@@ -16927,7 +17876,8 @@
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -16937,7 +17887,8 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "dev": true,
           "requires": {
             "defaults": "^1.0.3"
@@ -16945,7 +17896,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -16953,12 +17905,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -16966,7 +17920,8 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -16978,7 +17933,8 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "dev": true,
           "requires": {
             "string-width": "^2.1.1"
@@ -16986,41 +17942,68 @@
         },
         "worker-farm": {
           "version": "1.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+          "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
           "dev": true,
           "requires": {
             "errno": "~0.1.7"
           }
         },
         "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
             "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
               }
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -17030,56 +18013,140 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         },
         "yargs": {
-          "version": "11.1.1",
-          "bundled": true,
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.1.0",
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
+            "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
           },
           "dependencies": {
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true,
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "dev": true
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
             }
           }
         },
         "yargs-parser": {
-          "version": "9.0.2",
-          "bundled": true,
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
+            }
           }
         }
       }
@@ -17168,20 +18235,12 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.1.tgz",
+      "integrity": "sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        }
+        "mimic-fn": "^2.1.0"
       }
     },
     "os-browserify": {
@@ -17247,9 +18306,9 @@
       "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -17304,6 +18363,38 @@
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "parent-module": {
@@ -17330,9 +18421,9 @@
       }
     },
     "parse-json": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+      "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -17357,7 +18448,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -17388,9 +18480,9 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -17407,9 +18499,9 @@
       "dev": true
     },
     "pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pkg-conf": {
@@ -17696,37 +18788,23 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "picomatch": "^2.2.1"
       }
     },
     "redent": {
@@ -17759,9 +18837,9 @@
       }
     },
     "registry-auth-token": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
-      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
+      "integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
       "dev": true,
       "requires": {
         "rc": "^1.2.8"
@@ -17771,7 +18849,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -17811,12 +18890,20 @@
       "dev": true,
       "requires": {
         "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
     "resolve-url": {
@@ -17833,6 +18920,23 @@
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        }
       }
     },
     "ret": {
@@ -17872,22 +18976,18 @@
       }
     },
     "rlp": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
-      "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
       "requires": {
-        "bn.js": "^4.11.1",
-        "safe-buffer": "^5.1.1"
+        "bn.js": "^4.11.1"
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "run-parallel": {
       "version": "1.1.9",
@@ -17905,18 +19005,18 @@
       }
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -17955,16 +19055,16 @@
       }
     },
     "secp256k1": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
       "requires": {
         "bindings": "^1.5.0",
         "bip66": "^1.1.5",
         "bn.js": "^4.11.8",
         "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
-        "elliptic": "^6.4.1",
+        "elliptic": "^6.5.2",
         "nan": "^2.14.0",
         "safe-buffer": "^5.1.2"
       }
@@ -18021,15 +19121,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -18067,15 +19158,6 @@
             "which": "^2.0.1"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -18083,9 +19165,9 @@
           "dev": true
         },
         "execa": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -18097,24 +19179,6 @@
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2",
             "strip-final-newline": "^2.0.0"
-          }
-        },
-        "figures": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
           }
         },
         "find-up": {
@@ -18142,12 +19206,6 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -18163,28 +19221,6 @@
             "p-locate": "^4.1.0"
           }
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "npm-run-path": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -18192,15 +19228,6 @@
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
-          }
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
           }
         },
         "p-locate": {
@@ -18222,12 +19249,6 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         },
         "semver": {
@@ -18271,15 +19292,6 @@
             "ansi-regex": "^5.0.0"
           }
         },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -18301,9 +19313,9 @@
           }
         },
         "yargs": {
-          "version": "15.3.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "dev": true,
           "requires": {
             "cliui": "^6.0.0",
@@ -18316,7 +19328,7 @@
             "string-width": "^4.2.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.1"
+            "yargs-parser": "^18.1.2"
           }
         },
         "yargs-parser": {
@@ -18332,9 +19344,9 @@
       }
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -18360,10 +19372,13 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -18389,6 +19404,15 @@
           "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
           }
         }
       }
@@ -18445,9 +19469,9 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "signale": {
       "version": "1.4.0",
@@ -18458,6 +19482,17 @@
         "chalk": "^2.3.2",
         "figures": "^2.0.0",
         "pkg-conf": "^2.1.0"
+      },
+      "dependencies": {
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        }
       }
     },
     "slash": {
@@ -18482,6 +19517,15 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -18499,6 +19543,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -18681,6 +19731,48 @@
       "dev": true,
       "requires": {
         "through2": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "ssri": {
@@ -18721,6 +19813,38 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "stream-combiner2": {
@@ -18731,6 +19855,38 @@
       "requires": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "stream-each": {
@@ -18754,6 +19910,38 @@
         "readable-stream": "^2.3.6",
         "to-arraybuffer": "^1.0.0",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "stream-shift": {
@@ -18773,20 +19961,11 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -18912,9 +20091,9 @@
       }
     },
     "terser": {
-      "version": "4.6.13",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
-      "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -18923,16 +20102,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
+      "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^3.1.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -18958,13 +20137,13 @@
       "dev": true
     },
     "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
       }
     },
     "timers-browserify": {
@@ -19024,13 +20203,12 @@
       }
     },
     "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
       }
     },
     "traverse": {
@@ -19052,9 +20230,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tty-browserify": {
@@ -19076,9 +20254,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
       "dev": true,
       "optional": true
     },
@@ -19180,7 +20358,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "uri-js": {
       "version": "4.2.2",
@@ -19247,13 +20426,12 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-      "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -19273,14 +20451,269 @@
       "dev": true
     },
     "watchpack": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
-      "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.1.8",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
       }
     },
     "webpack": {
@@ -19312,6 +20745,111 @@
         "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.1",
         "webpack-sources": "^1.4.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
       }
     },
     "webpack-cli": {
@@ -19534,9 +21072,9 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {
@@ -19564,9 +21102,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -300,6 +300,173 @@
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
     },
+    "@semantic-release/git": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-9.0.0.tgz",
+      "integrity": "sha512-AZ4Zha5NAPAciIJH3ipzw/WU9qLAn8ENaoVAhD6srRPxTpTzuV3NhNh14rcAo8Paj9dO+5u4rTKcpetOBluYVw==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^2.1.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "execa": "^4.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.0",
+        "p-reduce": "^2.0.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "execa": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "@semantic-release/github": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.0.7.tgz",
@@ -2645,7 +2812,6 @@
           "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
           "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bignumber.js": "*"
           }
@@ -2697,7 +2863,6 @@
           "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
           "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "^2.2.0",
             "es5-ext": "^0.10.50",
@@ -2711,7 +2876,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -2720,15 +2884,13 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "nan": {
               "version": "2.14.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
               "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -2811,8 +2973,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "anymatch": {
           "version": "2.0.0",
@@ -2968,7 +3129,6 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
@@ -3897,8 +4057,7 @@
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
           "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "binary-extensions": {
           "version": "1.13.1",
@@ -3942,7 +4101,6 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -3966,7 +4124,6 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "content-type": "~1.0.4",
@@ -3985,7 +4142,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -3994,8 +4150,7 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -4088,7 +4243,6 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "randombytes": "^2.0.1"
@@ -4167,7 +4321,6 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -4177,8 +4330,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -4197,8 +4349,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -4210,8 +4361,7 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -4223,8 +4373,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -4604,8 +4753,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.7.0",
@@ -4642,8 +4790,7 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
@@ -4829,7 +4976,6 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -4839,7 +4985,6 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -5067,8 +5212,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "des.js": {
           "version": "1.0.1",
@@ -5085,8 +5229,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "detect-file": {
           "version": "1.0.0",
@@ -5145,8 +5288,7 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "duplexify": {
           "version": "3.7.1",
@@ -5184,8 +5326,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.341",
@@ -5212,8 +5353,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -5361,8 +5501,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -5380,8 +5519,7 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -5963,7 +6101,6 @@
           "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
           "integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "js-sha3": "^0.8.0"
           },
@@ -5972,8 +6109,7 @@
               "version": "0.8.0",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
               "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6175,7 +6311,6 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -6185,8 +6320,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6204,8 +6338,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "events": {
           "version": "3.1.0",
@@ -6530,8 +6663,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -6715,15 +6847,13 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-extra": {
           "version": "4.0.3",
@@ -7179,7 +7309,6 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -7192,8 +7321,7 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7201,8 +7329,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -8128,8 +8255,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
@@ -8239,8 +8365,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
@@ -8397,8 +8522,7 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-db": {
           "version": "1.43.0",
@@ -8419,8 +8543,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -8463,7 +8586,6 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8643,7 +8765,6 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -8653,8 +8774,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8804,7 +8924,6 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -8814,7 +8933,6 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -8887,7 +9005,6 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
           "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "asn1.js": "^4.0.0",
             "browserify-aes": "^1.0.0",
@@ -8939,8 +9056,7 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -9217,7 +9333,6 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
-          "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -9256,15 +9371,13 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -9295,15 +9408,13 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -9699,8 +9810,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
           "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "scrypt.js": {
           "version": "0.3.0",
@@ -9783,7 +9893,6 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -9805,7 +9914,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -9814,8 +9922,7 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             },
@@ -9823,8 +9930,7 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9901,8 +10007,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -9927,15 +10032,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
           "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -10214,8 +10317,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "stream-exhaust": {
           "version": "1.0.2",
@@ -10251,8 +10353,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -10496,7 +10597,6 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -10543,8 +10643,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tmp": {
           "version": "0.1.0",
@@ -10569,8 +10668,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -10640,8 +10738,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
@@ -10699,7 +10796,6 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
@@ -10769,8 +10865,7 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "undertaker": {
           "version": "1.2.1",
@@ -10834,8 +10929,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -10918,8 +11012,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "url-to-options": {
           "version": "1.0.1",
@@ -10938,8 +11031,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -11001,8 +11093,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "verror": {
           "version": "1.10.0",
@@ -11122,7 +11213,6 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
           "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/bignumber.js": "^5.0.0",
             "@types/bn.js": "^4.11.4",
@@ -11137,8 +11227,7 @@
               "version": "12.12.26",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
               "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11147,7 +11236,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
           "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.4",
@@ -11159,7 +11247,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
           "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -11173,7 +11260,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
           "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -11184,7 +11270,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
           "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -11198,7 +11283,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
           "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -11232,7 +11316,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
           "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -11243,22 +11326,19 @@
               "version": "10.17.14",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
               "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aes-js": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
               "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "elliptic": {
               "version": "6.3.3",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
               "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -11271,7 +11351,6 @@
               "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
               "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "@types/node": "^10.3.2",
                 "aes-js": "3.0.0",
@@ -11290,7 +11369,6 @@
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
               "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.0"
@@ -11300,22 +11378,19 @@
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
               "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "setimmediate": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
               "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "uuid": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
               "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11366,7 +11441,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
           "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.4",
             "underscore": "1.9.1",
@@ -11401,7 +11475,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
           "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.4"
@@ -11412,7 +11485,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
           "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/node": "^12.6.1",
             "web3-core": "1.2.4",
@@ -11426,8 +11498,7 @@
               "version": "12.12.26",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
               "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11436,7 +11507,6 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
           "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -11477,7 +11547,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
                 "ethereumjs-util": "^5.1.1"
               }
             },
@@ -11706,7 +11776,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
           "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.4",
             "xhr2-cookies": "1.1.0"
@@ -11717,7 +11786,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
           "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
           "dev": true,
-          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -11729,7 +11797,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
           "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@web3-js/websocket": "^1.0.29",
             "underscore": "1.9.1",
@@ -11754,7 +11821,6 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
           "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -11771,7 +11837,6 @@
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
@@ -11885,7 +11950,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -11901,7 +11965,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
           "dev": true,
-          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -11911,7 +11974,6 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
@@ -11920,8 +11982,7 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
           "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "xtend": {
           "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2584,9 +2584,9 @@
       }
     },
     "ganache-core": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.10.2.tgz",
-      "integrity": "sha512-4XEO0VsqQ1+OW7Za5fQs9/Kk7o8M0T1sRfFSF8h9NeJ2ABaqMO5waqxf567ZMcSkRKaTjUucBSz83xNfZv1HDg==",
+      "version": "2.11.0-beta.0",
+      "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.11.0-beta.0.tgz",
+      "integrity": "sha512-/1+io16xIjzZjq/6JG7G6AQzfnj8nipzoZ5RdpATZOFr6elR7HJGEDFJxoGxk8Nhvv8YOkewVKpFVsudvJdr+g==",
       "dev": true,
       "requires": {
         "abstract-leveldown": "3.0.0",
@@ -2603,12 +2603,13 @@
         "ethereumjs-common": "1.5.0",
         "ethereumjs-tx": "2.1.2",
         "ethereumjs-util": "6.2.0",
-        "ethereumjs-vm": "4.1.3",
+        "ethereumjs-vm": "4.2.0",
         "ethereumjs-wallet": "0.6.3",
         "heap": "0.2.6",
         "level-sublevel": "6.6.4",
         "levelup": "3.1.1",
         "lodash": "4.17.14",
+        "lru-cache": "5.1.1",
         "merkle-patricia-tree": "2.3.2",
         "seedrandom": "3.0.1",
         "source-map-support": "0.5.12",
@@ -2618,337 +2619,19 @@
         "websocket": "1.0.29"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-          "requires": {
-            "@babel/highlight": "^7.8.3"
-          }
-        },
-        "@babel/core": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
-          "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.8.3",
-            "@babel/helpers": "^7.8.3",
-            "@babel/parser": "^7.8.3",
-            "@babel/template": "^7.8.3",
-            "@babel/traverse": "^7.8.3",
-            "@babel/types": "^7.8.3",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.0",
-            "lodash": "^4.17.13",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "json5": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-              "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-              "requires": {
-                "minimist": "^1.2.0"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
-          }
-        },
-        "@babel/generator": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
-          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
-          "requires": {
-            "@babel/types": "^7.8.3",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "jsesc": {
-              "version": "2.5.2",
-              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-              "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.8.3",
-            "@babel/template": "^7.8.3",
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-          "requires": {
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-          "requires": {
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/helpers": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
-          "integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
-          "requires": {
-            "@babel/template": "^7.8.3",
-            "@babel/traverse": "^7.8.3",
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "js-tokens": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-              "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "@babel/parser": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-          "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ=="
-        },
-        "@babel/runtime": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-          "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.13.3",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-              "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-            }
-          }
-        },
-        "@babel/template": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/parser": "^7.8.3",
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
-          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.8.3",
-            "@babel/helper-function-name": "^7.8.3",
-            "@babel/helper-split-export-declaration": "^7.8.3",
-            "@babel/parser": "^7.8.3",
-            "@babel/types": "^7.8.3",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "globals": {
-              "version": "11.12.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-              "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-            }
-          }
-        },
-        "@babel/types": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          },
-          "dependencies": {
-            "to-fast-properties": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-              "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-            }
-          }
-        },
-        "@istanbuljs/load-nyc-config": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-          "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
-          "requires": {
-            "camelcase": "^5.3.1",
-            "find-up": "^4.1.0",
-            "js-yaml": "^3.13.1",
-            "resolve-from": "^5.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-            },
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-              "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-              "requires": {
-                "p-locate": "^4.1.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-              "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-              "requires": {
-                "p-limit": "^2.2.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-              "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-            },
-            "resolve-from": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-              "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-            }
-          }
-        },
-        "@istanbuljs/schema": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
-          "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
-        },
-        "@samverschueren/stream-to-observable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-          "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-          "requires": {
-            "any-observable": "^0.3.0"
-          }
-        },
         "@sindresorhus/is": {
           "version": "0.14.0",
           "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-          "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+          "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+          "dev": true,
+          "optional": true
         },
         "@szmarczak/http-timer": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
           "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "defer-to-connect": "^1.0.1"
           }
@@ -2957,6 +2640,8 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
           "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bignumber.js": "*"
           }
@@ -2965,37 +2650,23 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "dev": true,
           "requires": {
             "@types/node": "*"
           }
         },
-        "@types/color-name": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-        },
         "@types/node": {
           "version": "13.5.2",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
-          "integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA=="
-        },
-        "@types/parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
-        },
-        "@types/web3": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.2.2.tgz",
-          "integrity": "sha512-eFiYJKggNrOl0nsD+9cMh2MLk4zVBfXfGnVeRFbpiZzBE20eet4KLA3fXcjSuHaBn0RnQzwLAGdgzgzdet4C0A==",
-          "requires": {
-            "web3": "*"
-          }
+          "integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA==",
+          "dev": true
         },
         "@web3-js/scrypt-shim": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz",
           "integrity": "sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "scryptsy": "^2.1.0",
             "semver": "^6.3.0"
@@ -3004,12 +2675,16 @@
             "scryptsy": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-              "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
+              "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+              "dev": true,
+              "optional": true
             },
             "semver": {
               "version": "6.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -3017,6 +2692,8 @@
           "version": "1.0.30",
           "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
           "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^2.2.0",
             "es5-ext": "^0.10.50",
@@ -3029,6 +2706,8 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -3036,182 +2715,18 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true,
+              "optional": true
             },
             "nan": {
               "version": "2.14.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+              "dev": true,
+              "optional": true
             }
           }
-        },
-        "@webassemblyjs/ast": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-          "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
-          "requires": {
-            "@webassemblyjs/helper-module-context": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5"
-          }
-        },
-        "@webassemblyjs/floating-point-hex-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-          "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ=="
-        },
-        "@webassemblyjs/helper-api-error": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-          "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA=="
-        },
-        "@webassemblyjs/helper-buffer": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-          "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q=="
-        },
-        "@webassemblyjs/helper-code-frame": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-          "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
-          "requires": {
-            "@webassemblyjs/wast-printer": "1.8.5"
-          }
-        },
-        "@webassemblyjs/helper-fsm": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-          "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow=="
-        },
-        "@webassemblyjs/helper-module-context": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-          "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "mamacro": "^0.0.3"
-          }
-        },
-        "@webassemblyjs/helper-wasm-bytecode": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-          "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ=="
-        },
-        "@webassemblyjs/helper-wasm-section": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-          "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5"
-          }
-        },
-        "@webassemblyjs/ieee754": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-          "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
-          "requires": {
-            "@xtuc/ieee754": "^1.2.0"
-          }
-        },
-        "@webassemblyjs/leb128": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-          "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
-          "requires": {
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/utf8": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-          "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw=="
-        },
-        "@webassemblyjs/wasm-edit": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-          "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/helper-wasm-section": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5",
-            "@webassemblyjs/wasm-opt": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5",
-            "@webassemblyjs/wast-printer": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-gen": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-          "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/ieee754": "1.8.5",
-            "@webassemblyjs/leb128": "1.8.5",
-            "@webassemblyjs/utf8": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-opt": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-          "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-buffer": "1.8.5",
-            "@webassemblyjs/wasm-gen": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wasm-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-          "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-api-error": "1.8.5",
-            "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-            "@webassemblyjs/ieee754": "1.8.5",
-            "@webassemblyjs/leb128": "1.8.5",
-            "@webassemblyjs/utf8": "1.8.5"
-          }
-        },
-        "@webassemblyjs/wast-parser": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-          "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-            "@webassemblyjs/helper-api-error": "1.8.5",
-            "@webassemblyjs/helper-code-frame": "1.8.5",
-            "@webassemblyjs/helper-fsm": "1.8.5",
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/wast-printer": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-          "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/wast-parser": "1.8.5",
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@xtuc/ieee754": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-          "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
-        },
-        "@xtuc/long": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-          "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "abstract-leveldown": {
           "version": "3.0.0",
@@ -3226,20 +2741,12 @@
           "version": "1.3.7",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
           "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "mime-types": "~2.1.24",
             "negotiator": "0.6.2"
           }
-        },
-        "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
-        },
-        "acorn-jsx": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-          "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
         },
         "aes-js": {
           "version": "3.1.2",
@@ -3248,42 +2755,17 @@
           "dev": true,
           "optional": true
         },
-        "aggregate-error": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-          "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
-          "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^4.0.0"
-          },
-          "dependencies": {
-            "indent-string": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-              "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
-            }
-          }
-        },
         "ajv": {
           "version": "6.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
           "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
-        },
-        "ajv-errors": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-          "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
-        },
-        "ajv-keywords": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
         },
         "ansi-colors": {
           "version": "1.1.0",
@@ -3292,14 +2774,6 @@
           "dev": true,
           "requires": {
             "ansi-wrap": "^0.1.0"
-          }
-        },
-        "ansi-escapes": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-          "requires": {
-            "type-fest": "^0.8.1"
           }
         },
         "ansi-gray": {
@@ -3314,12 +2788,14 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "ansi-wrap": {
           "version": "0.1.0",
@@ -3327,20 +2803,18 @@
           "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
           "dev": true
         },
-        "any-observable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-          "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
-        },
         "any-promise": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+          "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+          "dev": true,
+          "optional": true
         },
         "anymatch": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
           "requires": {
             "micromatch": "^3.1.4",
             "normalize-path": "^2.1.1"
@@ -3355,36 +2829,17 @@
             "buffer-equal": "^1.0.0"
           }
         },
-        "append-transform": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-          "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-          "requires": {
-            "default-require-extensions": "^3.0.0"
-          }
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-        },
         "archy": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
         },
         "arr-filter": {
           "version": "1.1.2",
@@ -3398,7 +2853,8 @@
         "arr-flatten": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+          "dev": true
         },
         "arr-map": {
           "version": "2.0.2",
@@ -3412,7 +2868,8 @@
         "arr-union": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+          "dev": true
         },
         "array-each": {
           "version": "1.0.1",
@@ -3423,17 +2880,9 @@
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-        },
-        "array-includes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-          "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0",
-            "is-string": "^1.0.5"
-          }
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true,
+          "optional": true
         },
         "array-initial": {
           "version": "1.1.0",
@@ -3498,21 +2947,14 @@
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-        },
-        "array.prototype.flat": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-          "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1"
-          }
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
         },
         "asn1": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
           "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
           }
@@ -3521,51 +2963,31 @@
           "version": "4.10.1",
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
             "minimalistic-assert": "^1.0.0"
           }
         },
-        "assert": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-          "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
-          "requires": {
-            "object-assign": "^4.1.1",
-            "util": "0.10.3"
-          }
-        },
-        "assert-match": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/assert-match/-/assert-match-1.1.1.tgz",
-          "integrity": "sha512-c0QY2kpYVrH/jis6cCq9Mnt4/bIdGALDh1N8HY9ZARZedsMs5LSbgywxkjd5A1uNVLN0L8evANxBPxKiabVoZw==",
-          "requires": {
-            "assert": "^1.4.1",
-            "babel-runtime": "^6.23.0",
-            "es-to-primitive": "^1.1.1",
-            "lodash.merge": "^4.6.0"
-          }
-        },
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-        },
-        "astral-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+          "dev": true
         },
         "async": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
           "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "dev": true,
           "requires": {
             "lodash": "^4.17.11"
           }
@@ -3585,7 +3007,8 @@
         "async-each": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-          "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+          "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+          "dev": true
         },
         "async-eventemitter": {
           "version": "0.2.4",
@@ -3599,7 +3022,8 @@
         "async-limiter": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-          "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+          "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+          "dev": true
         },
         "async-settle": {
           "version": "1.0.0",
@@ -3613,22 +3037,26 @@
         "asynckit": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "dev": true
         },
         "atob": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-          "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+          "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+          "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
         },
         "aws4": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+          "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
@@ -4260,6 +3688,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "^2.4.0",
             "regenerator-runtime": "^0.11.0"
@@ -4369,12 +3798,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
         },
         "base": {
           "version": "0.11.2",
           "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+          "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
             "class-utils": "^0.3.5",
@@ -4389,6 +3820,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -4397,6 +3829,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -4405,6 +3838,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -4413,6 +3847,7 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -4434,12 +3869,14 @@
         "base64-js": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-          "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+          "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
           "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+          "dev": true,
           "requires": {
             "tweetnacl": "^0.14.3"
           },
@@ -4447,29 +3884,29 @@
             "tweetnacl": {
               "version": "0.14.5",
               "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+              "dev": true
             }
           }
-        },
-        "big.js": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
         },
         "bignumber.js": {
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+          "dev": true,
+          "optional": true
         },
         "binary-extensions": {
           "version": "1.13.1",
           "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true
         },
         "bindings": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
           "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "dev": true,
           "requires": {
             "file-uri-to-path": "1.0.0"
           }
@@ -4491,6 +3928,7 @@
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
           "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -4499,6 +3937,8 @@
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -4507,17 +3947,22 @@
         "bluebird": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+          "dev": true,
+          "optional": true
         },
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
         },
         "body-parser": {
           "version": "1.19.0",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "content-type": "~1.0.4",
@@ -4535,6 +3980,8 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4542,7 +3989,9 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4550,6 +3999,7 @@
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4559,6 +4009,7 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -4576,6 +4027,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4585,26 +4037,14 @@
         "brorand": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-        },
-        "browser-stdout": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
-        },
-        "browserfs": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.4.3.tgz",
-          "integrity": "sha512-tz8HClVrzTJshcyIu8frE15cjqjcBIu15Bezxsvl/i+6f59iNCN3kznlWjz0FEb3DlnDx3gW5szxeT6D1x0s0w==",
-          "requires": {
-            "async": "^2.1.4",
-            "pako": "^1.0.4"
-          }
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+          "dev": true
         },
         "browserify-aes": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+          "dev": true,
           "requires": {
             "buffer-xor": "^1.0.3",
             "cipher-base": "^1.0.0",
@@ -4618,6 +4058,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
           "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "browserify-aes": "^1.0.4",
             "browserify-des": "^1.0.0",
@@ -4628,6 +4070,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
           "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "cipher-base": "^1.0.1",
             "des.js": "^1.0.0",
@@ -4639,6 +4083,8 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "randombytes": "^2.0.1"
@@ -4658,6 +4104,8 @@
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
           "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.1.1",
             "browserify-rsa": "^4.0.0",
@@ -4666,14 +4114,6 @@
             "elliptic": "^6.0.0",
             "inherits": "^2.0.1",
             "parse-asn1": "^5.0.0"
-          }
-        },
-        "browserify-zlib": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-          "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-          "requires": {
-            "pako": "~1.0.5"
           }
         },
         "browserslist": {
@@ -4712,6 +4152,7 @@
           "version": "5.4.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
           "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -4721,6 +4162,8 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -4729,12 +4172,16 @@
         "buffer-alloc-unsafe": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+          "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+          "dev": true,
+          "optional": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
           "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-          "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+          "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+          "dev": true,
+          "optional": true
         },
         "buffer-equal": {
           "version": "1.0.0",
@@ -4745,32 +4192,35 @@
         "buffer-fill": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+          "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+          "dev": true,
+          "optional": true
         },
         "buffer-from": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+          "dev": true
         },
         "buffer-to-arraybuffer": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-          "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+          "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
+          "dev": true,
+          "optional": true
         },
         "buffer-xor": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-        },
-        "builtin-status-codes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-          "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+          "dev": true
         },
         "bytes": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+          "dev": true,
+          "optional": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -4791,89 +4241,11 @@
             "typewise-core": "^1.2"
           }
         },
-        "cacache": {
-          "version": "13.0.1",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
-          "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
-          "requires": {
-            "chownr": "^1.1.2",
-            "figgy-pudding": "^3.5.1",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
-            "infer-owner": "^1.0.4",
-            "lru-cache": "^5.1.1",
-            "minipass": "^3.0.0",
-            "minipass-collect": "^1.0.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "p-map": "^3.0.0",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.7.1",
-            "ssri": "^7.0.0",
-            "unique-filename": "^1.1.1"
-          },
-          "dependencies": {
-            "fs-minipass": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-              "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-              "requires": {
-                "minipass": "^3.0.0"
-              }
-            },
-            "lru-cache": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-              "requires": {
-                "yallist": "^3.0.2"
-              },
-              "dependencies": {
-                "yallist": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                  "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-                }
-              }
-            },
-            "minipass": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "p-map": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-              "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-              "requires": {
-                "aggregate-error": "^3.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-            }
-          }
-        },
         "cache-base": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
             "component-emitter": "^1.2.1",
@@ -4890,6 +4262,8 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
           "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "clone-response": "^1.0.2",
             "get-stream": "^5.1.0",
@@ -4904,6 +4278,8 @@
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
               "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "pump": "^3.0.0"
               }
@@ -4911,7 +4287,9 @@
             "lowercase-keys": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4933,39 +4311,17 @@
               "requires": {
                 "xtend": "~4.0.0"
               }
-            }
-          }
-        },
-        "caching-transform": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
-          "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
-          "requires": {
-            "hasha": "^5.0.0",
-            "make-dir": "^3.0.0",
-            "package-hash": "^4.0.0",
-            "write-file-atomic": "^3.0.0"
-          },
-          "dependencies": {
-            "make-dir": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-              "requires": {
-                "semver": "^6.0.0"
-              }
             },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            "lru-cache": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+              "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+              "dev": true,
+              "requires": {
+                "pseudomap": "^1.0.1"
+              }
             }
           }
-        },
-        "callsites": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         },
         "camelcase": {
           "version": "3.0.0",
@@ -4982,12 +4338,14 @@
         "caseless": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -4995,11 +4353,6 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
-        },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
         },
         "checkpoint-store": {
           "version": "1.1.0",
@@ -5014,11 +4367,11 @@
           "version": "2.1.8",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -5032,32 +4385,23 @@
             "normalize-path": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+              "dev": true
             }
           }
         },
         "chownr": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
-        },
-        "chrome-trace-event": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-          "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "ci-info": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+          "dev": true,
+          "optional": true
         },
         "cipher-base": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -5067,6 +4411,7 @@
           "version": "0.3.6",
           "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+          "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
             "define-property": "^0.2.5",
@@ -5078,45 +4423,12 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             }
           }
-        },
-        "clean-stack": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "cli-truncate": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-          "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-          "requires": {
-            "slice-ansi": "0.0.4",
-            "string-width": "^1.0.1"
-          },
-          "dependencies": {
-            "slice-ansi": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-              "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-            }
-          }
-        },
-        "cli-width": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
         },
         "cliui": {
           "version": "3.2.0",
@@ -5145,6 +4457,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
           "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -5169,7 +4483,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
         },
         "coinstring": {
           "version": "2.3.0",
@@ -5206,23 +4521,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
             "object-visit": "^1.0.0"
           }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "color-support": {
           "version": "1.1.3",
@@ -5234,42 +4537,38 @@
           "version": "1.0.8",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
-        },
-        "command-exists": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-          "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw=="
         },
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
         },
-        "commondir": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-        },
         "component-emitter": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -5277,25 +4576,12 @@
             "typedarray": "^0.0.6"
           }
         },
-        "console-browserify": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-          "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
-        },
-        "constants-browserify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-          "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
-        },
-        "contains-path": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-          "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
-        },
         "content-disposition": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
           "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "5.1.2"
           },
@@ -5303,19 +4589,24 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true,
+              "optional": true
             }
           }
         },
         "content-type": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+          "dev": true,
+          "optional": true
         },
         "convert-source-map": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
           "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
           },
@@ -5323,52 +4614,37 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
             }
           }
         },
         "cookie": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+          "dev": true,
+          "optional": true
         },
         "cookie-signature": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+          "dev": true,
+          "optional": true
         },
         "cookiejar": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
-        },
-        "copy-concurrently": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-          "requires": {
-            "aproba": "^1.1.1",
-            "fs-write-stream-atomic": "^1.0.8",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.0"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            }
-          }
+          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+          "dev": true,
+          "optional": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+          "dev": true
         },
         "copy-props": {
           "version": "2.0.4",
@@ -5383,81 +4659,38 @@
         "core-js": {
           "version": "2.6.11",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
         },
         "core-js-pure": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
-          "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+          "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
         },
         "cors": {
           "version": "2.8.5",
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
           "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "object-assign": "^4",
             "vary": "^1"
-          }
-        },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          },
-          "dependencies": {
-            "parse-json": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-              "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-              "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1",
-                "lines-and-columns": "^1.1.6"
-              }
-            },
-            "path-type": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-              "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-            }
-          }
-        },
-        "coveralls": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
-          "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
-          "requires": {
-            "js-yaml": "^3.13.1",
-            "lcov-parse": "^1.0.0",
-            "log-driver": "^1.2.7",
-            "minimist": "^1.2.0",
-            "request": "^2.88.0"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            }
           }
         },
         "create-ecdh": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
           "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "elliptic": "^6.0.0"
@@ -5467,6 +4700,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+          "dev": true,
           "requires": {
             "cipher-base": "^1.0.1",
             "inherits": "^2.0.1",
@@ -5479,6 +4713,7 @@
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+          "dev": true,
           "requires": {
             "cipher-base": "^1.0.3",
             "create-hash": "^1.1.0",
@@ -5486,14 +4721,6 @@
             "ripemd160": "^2.0.0",
             "safe-buffer": "^5.0.1",
             "sha.js": "^2.4.8"
-          }
-        },
-        "cross-env": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
-          "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
-          "requires": {
-            "cross-spawn": "^7.0.0"
           }
         },
         "cross-fetch": {
@@ -5506,30 +4733,12 @@
             "whatwg-fetch": "2.0.4"
           }
         },
-        "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          },
-          "dependencies": {
-            "which": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            }
-          }
-        },
         "crypto-browserify": {
           "version": "3.12.0",
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
           "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "browserify-cipher": "^1.0.0",
             "browserify-sign": "^4.0.0",
@@ -5544,15 +4753,11 @@
             "randomfill": "^1.0.3"
           }
         },
-        "cyclist": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
-          "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
-        },
         "d": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
           "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+          "dev": true,
           "requires": {
             "es5-ext": "^0.10.50",
             "type": "^1.0.1"
@@ -5562,19 +4767,16 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
-        },
-        "date-fns": {
-          "version": "1.30.1",
-          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
         },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -5582,17 +4784,21 @@
         "decamelize": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+          "dev": true
         },
         "decompress": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
           "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "decompress-tar": "^4.0.0",
             "decompress-tarbz2": "^4.0.0",
@@ -5607,7 +4813,9 @@
             "pify": {
               "version": "2.3.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -5615,6 +4823,8 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -5623,6 +4833,8 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -5633,6 +4845,8 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
           "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "decompress-tar": "^4.1.0",
             "file-type": "^6.1.0",
@@ -5644,7 +4858,9 @@
             "file-type": {
               "version": "6.2.0",
               "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-              "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+              "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -5652,6 +4868,8 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
           "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "decompress-tar": "^4.1.1",
             "file-type": "^5.2.0",
@@ -5662,6 +4880,8 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
           "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "file-type": "^3.8.0",
             "get-stream": "^2.2.0",
@@ -5672,12 +4892,16 @@
             "file-type": {
               "version": "3.9.0",
               "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-              "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+              "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+              "dev": true,
+              "optional": true
             },
             "get-stream": {
               "version": "2.3.1",
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
               "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "object-assign": "^4.0.1",
                 "pinkie-promise": "^2.0.0"
@@ -5686,14 +4910,11 @@
             "pify": {
               "version": "2.3.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true,
+              "optional": true
             }
           }
-        },
-        "dedent": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-          "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
         },
         "deep-equal": {
           "version": "1.1.1",
@@ -5717,11 +4938,6 @@
             }
           }
         },
-        "deep-is": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-        },
         "default-compare": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
@@ -5739,21 +4955,6 @@
             }
           }
         },
-        "default-require-extensions": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-          "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
-          "requires": {
-            "strip-bom": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-bom": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-              "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
-            }
-          }
-        },
         "default-resolution": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
@@ -5763,7 +4964,9 @@
         "defer-to-connect": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-          "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
+          "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+          "dev": true,
+          "optional": true
         },
         "deferred-leveldown": {
           "version": "1.2.2",
@@ -5789,6 +4992,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           },
@@ -5796,7 +5000,8 @@
             "object-keys": {
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-              "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+              "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+              "dev": true
             }
           }
         },
@@ -5804,6 +5009,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -5813,6 +5019,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -5821,6 +5028,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -5829,6 +5037,7 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -5846,17 +5055,22 @@
         "delayed-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "dev": true
         },
         "depd": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+          "dev": true,
+          "optional": true
         },
         "des.js": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
           "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "^2.0.1",
             "minimalistic-assert": "^1.0.0"
@@ -5865,12 +5079,15 @@
         "destroy": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+          "dev": true,
+          "optional": true
         },
         "detect-file": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+          "dev": true
         },
         "detect-indent": {
           "version": "4.0.0",
@@ -5881,38 +5098,23 @@
             "repeating": "^2.0.0"
           }
         },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-        },
         "diffie-hellman": {
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
           "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "miller-rabin": "^4.0.0",
             "randombytes": "^2.0.0"
           }
         },
-        "doctrine": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
         "dom-walk": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-          "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-        },
-        "domain-browser": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-          "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+          "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+          "dev": true
         },
         "dotignore": {
           "version": "0.1.2",
@@ -5927,6 +5129,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
           "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+          "dev": true,
           "requires": {
             "browserify-aes": "^1.0.6",
             "create-hash": "^1.1.2",
@@ -5936,12 +5139,15 @@
         "duplexer3": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+          "dev": true,
+          "optional": true
         },
         "duplexify": {
           "version": "3.7.1",
           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
           "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+          "dev": true,
           "requires": {
             "end-of-stream": "^1.0.0",
             "inherits": "^2.0.1",
@@ -5963,6 +5169,7 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
           "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+          "dev": true,
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
@@ -5971,7 +5178,9 @@
         "ee-first": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+          "dev": true,
+          "optional": true
         },
         "electron-to-chromium": {
           "version": "1.3.341",
@@ -5979,15 +5188,11 @@
           "integrity": "sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g==",
           "dev": true
         },
-        "elegant-spinner": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-          "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
-        },
         "elliptic": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
           "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -5998,20 +5203,12 @@
             "minimalistic-crypto-utils": "^1.0.0"
           }
         },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-        },
         "encodeurl": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+          "dev": true,
+          "optional": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -6050,35 +5247,16 @@
           "version": "1.4.4",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
           "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+          "dev": true,
           "requires": {
             "once": "^1.4.0"
-          }
-        },
-        "enhanced-resolve": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-          "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "memory-fs": "^0.5.0",
-            "tapable": "^1.0.0"
-          },
-          "dependencies": {
-            "memory-fs": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-              "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-              "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
-              }
-            }
           }
         },
         "errno": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
           "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+          "dev": true,
           "requires": {
             "prr": "~1.0.1"
           }
@@ -6087,6 +5265,7 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
           "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+          "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
           }
@@ -6095,6 +5274,7 @@
           "version": "1.17.4",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
           "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -6112,7 +5292,8 @@
             "object-keys": {
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-              "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+              "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+              "dev": true
             }
           }
         },
@@ -6120,6 +5301,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -6130,21 +5312,18 @@
           "version": "0.10.53",
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
           "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+          "dev": true,
           "requires": {
             "es6-iterator": "~2.0.3",
             "es6-symbol": "~3.1.3",
             "next-tick": "~1.0.0"
           }
         },
-        "es6-error": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-          "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
-        },
         "es6-iterator": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
           "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+          "dev": true,
           "requires": {
             "d": "1",
             "es5-ext": "^0.10.35",
@@ -6155,6 +5334,7 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
           "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+          "dev": true,
           "requires": {
             "d": "^1.0.1",
             "ext": "^1.1.2"
@@ -6175,463 +5355,28 @@
         "escape-html": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+          "dev": true,
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "eslint": {
-          "version": "6.8.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-          "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "ajv": "^6.10.0",
-            "chalk": "^2.1.0",
-            "cross-spawn": "^6.0.5",
-            "debug": "^4.0.1",
-            "doctrine": "^3.0.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^1.4.3",
-            "eslint-visitor-keys": "^1.1.0",
-            "espree": "^6.1.2",
-            "esquery": "^1.0.1",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^5.0.1",
-            "functional-red-black-tree": "^1.0.1",
-            "glob-parent": "^5.0.0",
-            "globals": "^12.1.0",
-            "ignore": "^4.0.6",
-            "import-fresh": "^3.0.0",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^7.0.0",
-            "is-glob": "^4.0.0",
-            "js-yaml": "^3.13.1",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.14",
-            "minimatch": "^3.0.4",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.3",
-            "progress": "^2.0.0",
-            "regexpp": "^2.0.1",
-            "semver": "^6.1.2",
-            "strip-ansi": "^5.2.0",
-            "strip-json-comments": "^3.0.1",
-            "table": "^5.2.3",
-            "text-table": "^0.2.0",
-            "v8-compile-cache": "^2.0.3"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-            },
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "cross-spawn": {
-              "version": "6.0.5",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              },
-              "dependencies": {
-                "semver": {
-                  "version": "5.7.1",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                  "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                }
-              }
-            },
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "glob-parent": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-              "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-              "requires": {
-                "is-glob": "^4.0.1"
-              }
-            },
-            "globals": {
-              "version": "12.3.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-              "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
-              "requires": {
-                "type-fest": "^0.8.1"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "path-key": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            },
-            "shebang-command": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-              "requires": {
-                "shebang-regex": "^1.0.0"
-              }
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "eslint-config-standard": {
-          "version": "14.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
-          "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA=="
-        },
-        "eslint-import-resolver-node": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
-          "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
-          "requires": {
-            "debug": "^2.6.9",
-            "resolve": "^1.13.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
-        },
-        "eslint-module-utils": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
-          "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
-          "requires": {
-            "debug": "^2.6.9",
-            "pkg-dir": "^2.0.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
-        },
-        "eslint-plugin-es": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
-          "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
-          "requires": {
-            "eslint-utils": "^2.0.0",
-            "regexpp": "^3.0.0"
-          },
-          "dependencies": {
-            "eslint-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-              "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
-              "requires": {
-                "eslint-visitor-keys": "^1.1.0"
-              }
-            },
-            "regexpp": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-              "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
-            }
-          }
-        },
-        "eslint-plugin-import": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.0.tgz",
-          "integrity": "sha512-NK42oA0mUc8Ngn4kONOPsPB1XhbUvNHqF+g307dPV28aknPoiNnKLFd9em4nkswwepdF5ouieqv5Th/63U7YJQ==",
-          "requires": {
-            "array-includes": "^3.0.3",
-            "array.prototype.flat": "^1.2.1",
-            "contains-path": "^0.1.0",
-            "debug": "^2.6.9",
-            "doctrine": "1.5.0",
-            "eslint-import-resolver-node": "^0.3.2",
-            "eslint-module-utils": "^2.4.1",
-            "has": "^1.0.3",
-            "minimatch": "^3.0.4",
-            "object.values": "^1.1.0",
-            "read-pkg-up": "^2.0.0",
-            "resolve": "^1.12.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "doctrine": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-              "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-              "requires": {
-                "esutils": "^2.0.2",
-                "isarray": "^1.0.0"
-              }
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "load-json-file": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "strip-bom": "^3.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            },
-            "path-type": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-              "requires": {
-                "pify": "^2.0.0"
-              }
-            },
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-            },
-            "read-pkg": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-              "requires": {
-                "load-json-file": "^2.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-              "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^2.0.0"
-              }
-            },
-            "strip-bom": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-            }
-          }
-        },
-        "eslint-plugin-node": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.0.0.tgz",
-          "integrity": "sha512-chUs/NVID+sknFiJzxoN9lM7uKSOEta8GC8365hw1nDfwIPIjjpRSwwPvQanWv8dt/pDe9EV4anmVSwdiSndNg==",
-          "requires": {
-            "eslint-plugin-es": "^3.0.0",
-            "eslint-utils": "^2.0.0",
-            "ignore": "^5.1.1",
-            "minimatch": "^3.0.4",
-            "resolve": "^1.10.1",
-            "semver": "^6.1.0"
-          },
-          "dependencies": {
-            "eslint-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-              "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
-              "requires": {
-                "eslint-visitor-keys": "^1.1.0"
-              }
-            },
-            "ignore": {
-              "version": "5.1.4",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-              "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
-          }
-        },
-        "eslint-plugin-promise": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
-          "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw=="
-        },
-        "eslint-plugin-standard": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
-          "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ=="
-        },
-        "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "eslint-utils": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
-        },
-        "espree": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-          "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
-          "requires": {
-            "acorn": "^7.1.0",
-            "acorn-jsx": "^5.1.0",
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
-        "esquery": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-          "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-          "requires": {
-            "estraverse": "^4.0.0"
-          }
-        },
-        "esrecurse": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-          "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-          "requires": {
-            "estraverse": "^4.1.0"
-          }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
         },
         "esutils": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-          "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+          "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+          "dev": true
         },
         "etag": {
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+          "dev": true,
+          "optional": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -6685,6 +5430,8 @@
           "version": "2.0.8",
           "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
           "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "idna-uts46-hx": "^2.3.1",
             "js-sha3": "^0.5.7"
@@ -6693,7 +5440,9 @@
             "js-sha3": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6905,6 +5654,8 @@
           "version": "0.1.29",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
           "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -7206,6 +5957,8 @@
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
           "integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "js-sha3": "^0.8.0"
           },
@@ -7213,7 +5966,9 @@
             "js-sha3": {
               "version": "0.8.0",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-              "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+              "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -7321,12 +6076,14 @@
         "ethereumjs-common": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
-          "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ=="
+          "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ==",
+          "dev": true
         },
         "ethereumjs-tx": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
           "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "dev": true,
           "requires": {
             "ethereumjs-common": "^1.5.0",
             "ethereumjs-util": "^6.0.0"
@@ -7336,6 +6093,7 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
           "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+          "dev": true,
           "requires": {
             "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
@@ -7346,62 +6104,6 @@
             "secp256k1": "^3.0.1"
           },
           "dependencies": {
-            "keccak": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-              "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-              "requires": {
-                "bindings": "^1.5.0",
-                "inherits": "^2.0.4",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.2.0"
-              }
-            },
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-            }
-          }
-        },
-        "ethereumjs-vm": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.1.3.tgz",
-          "integrity": "sha512-RTrD0y7My4O6Qr1P2ZIsMfD6RzL6kU/RhBZ0a5XrPzAeR61crBS7or66ohDrvxDI/rDBxMi+6SnsELih6fzalw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.1.2",
-            "async-eventemitter": "^0.2.2",
-            "core-js-pure": "^3.0.1",
-            "ethereumjs-account": "^3.0.0",
-            "ethereumjs-block": "^2.2.2",
-            "ethereumjs-blockchain": "^4.0.3",
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-tx": "^2.1.2",
-            "ethereumjs-util": "^6.2.0",
-            "fake-merkle-patricia-tree": "^1.0.1",
-            "functional-red-black-tree": "^1.0.1",
-            "merkle-patricia-tree": "^2.3.2",
-            "rustbn.js": "~0.2.0",
-            "safe-buffer": "^5.1.1",
-            "util.promisify": "^1.0.0"
-          },
-          "dependencies": {
-            "ethereumjs-util": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-              "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-              "dev": true,
-              "requires": {
-                "@types/bn.js": "^4.11.3",
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "ethjs-util": "0.1.6",
-                "keccak": "^2.0.0",
-                "rlp": "^2.2.3",
-                "secp256k1": "^3.0.1"
-              }
-            },
             "keccak": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
@@ -7422,6 +6124,29 @@
             }
           }
         },
+        "ethereumjs-vm": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
+          "integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
+          "dev": true,
+          "requires": {
+            "async": "^2.1.2",
+            "async-eventemitter": "^0.2.2",
+            "core-js-pure": "^3.0.1",
+            "ethereumjs-account": "^3.0.0",
+            "ethereumjs-block": "^2.2.2",
+            "ethereumjs-blockchain": "^4.0.3",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-tx": "^2.1.2",
+            "ethereumjs-util": "^6.2.0",
+            "fake-merkle-patricia-tree": "^1.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "merkle-patricia-tree": "^2.3.2",
+            "rustbn.js": "~0.2.0",
+            "safe-buffer": "^5.1.1",
+            "util.promisify": "^1.0.0"
+          }
+        },
         "ethereumjs-wallet": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz",
@@ -7440,62 +6165,12 @@
             "uuid": "^3.3.2"
           }
         },
-        "ethers": {
-          "version": "4.0.43",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.43.tgz",
-          "integrity": "sha512-VjQRVgPrlU12jSMvypdE1yEqYQccdVbH8bbiz67dLF7raHlRV4+zW70GlxHcZYqgsnz0XYWrn6C06gqTQRb5tw==",
-          "requires": {
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.5.2",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          },
-          "dependencies": {
-            "aes-js": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-              "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-            },
-            "hash.js": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-              "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-              "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.0"
-              }
-            },
-            "js-sha3": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-            },
-            "scrypt-js": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-              "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-            },
-            "setimmediate": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-            },
-            "uuid": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-              "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-            }
-          }
-        },
         "ethjs-unit": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -7504,7 +6179,9 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -7512,6 +6189,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
           "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+          "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0",
             "strip-hex-prefix": "1.0.0"
@@ -7520,63 +6198,31 @@
         "eventemitter3": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true,
+          "optional": true
         },
         "events": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-          "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+          "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+          "dev": true
         },
         "evp_bytestokey": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+          "dev": true,
           "requires": {
             "md5.js": "^1.3.4",
             "safe-buffer": "^5.1.1"
-          }
-        },
-        "execa": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-              "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-              "requires": {
-                "pump": "^3.0.0"
-              }
-            },
-            "is-stream": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-              "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-            },
-            "p-finally": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-              "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
-            }
           }
         },
         "expand-brackets": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -7591,6 +6237,7 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -7599,6 +6246,7 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -7607,6 +6255,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -7614,7 +6263,8 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             }
           }
         },
@@ -7622,6 +6272,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "dev": true,
           "requires": {
             "homedir-polyfill": "^1.0.1"
           }
@@ -7630,6 +6281,8 @@
           "version": "4.17.1",
           "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
           "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "accepts": "~1.3.7",
             "array-flatten": "1.1.1",
@@ -7667,6 +6320,8 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -7674,12 +6329,16 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true,
+              "optional": true
             },
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -7687,6 +6346,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
           "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+          "dev": true,
           "requires": {
             "type": "^2.0.0"
           },
@@ -7694,19 +6354,22 @@
             "type": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-              "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+              "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+              "dev": true
             }
           }
         },
         "extend": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+          "dev": true
         },
         "extend-shallow": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -7716,28 +6379,9 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "external-editor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-          "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          },
-          "dependencies": {
-            "tmp": {
-              "version": "0.0.33",
-              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-              "requires": {
-                "os-tmpdir": "~1.0.2"
               }
             }
           }
@@ -7746,6 +6390,7 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -7761,6 +6406,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -7769,6 +6415,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -7777,6 +6424,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -7785,6 +6433,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -7793,6 +6442,7 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -7804,7 +6454,8 @@
         "extsprintf": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+          "dev": true
         },
         "fake-merkle-patricia-tree": {
           "version": "1.0.1",
@@ -7830,22 +6481,21 @@
         "fast-deep-equal": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+          "dev": true
         },
         "fd-slicer": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "pend": "~1.2.0"
           }
@@ -7871,46 +6521,24 @@
             }
           }
         },
-        "figgy-pudding": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
-        },
-        "figures": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "file-entry-cache": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-          "requires": {
-            "flat-cache": "^2.0.1"
-          }
-        },
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "dev": true,
+          "optional": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-        },
-        "filesize": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-          "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+          "dev": true
         },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -7922,6 +6550,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -7932,6 +6561,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
           "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "encodeurl": "~1.0.2",
@@ -7946,6 +6577,8 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -7953,83 +6586,9 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
-        },
-        "find-cache-dir": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-          "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^3.0.0",
-            "pkg-dir": "^4.1.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-              "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-              "requires": {
-                "p-locate": "^4.1.0"
-              }
-            },
-            "make-dir": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-              "requires": {
-                "semver": "^6.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-              "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-              "requires": {
-                "p-limit": "^2.2.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-              "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-            },
-            "pkg-dir": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-              "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-              "requires": {
-                "find-up": "^4.0.0"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8047,6 +6606,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
           "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+          "dev": true,
           "requires": {
             "detect-file": "^1.0.0",
             "is-glob": "^4.0.0",
@@ -8073,46 +6633,6 @@
           "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
           "dev": true
         },
-        "flat": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-          "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-          "requires": {
-            "is-buffer": "~2.0.3"
-          },
-          "dependencies": {
-            "is-buffer": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-              "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-            }
-          }
-        },
-        "flat-cache": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-          "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-          "requires": {
-            "flatted": "^2.0.0",
-            "rimraf": "2.6.3",
-            "write": "1.0.3"
-          },
-          "dependencies": {
-            "rimraf": {
-              "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "flatted": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-          "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
-        },
         "flow-stoplight": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/flow-stoplight/-/flow-stoplight-1.0.0.tgz",
@@ -8123,6 +6643,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
           "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "readable-stream": "^2.3.6"
@@ -8140,7 +6661,8 @@
         "for-in": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+          "dev": true
         },
         "for-own": {
           "version": "1.0.0",
@@ -8151,24 +6673,17 @@
             "for-in": "^1.0.1"
           }
         },
-        "foreground-child": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-          "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
         "forever-agent": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "dev": true
         },
         "form-data": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -8178,12 +6693,15 @@
         "forwarded": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+          "dev": true,
+          "optional": true
         },
         "fragment-cache": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
           }
@@ -8191,31 +6709,23 @@
         "fresh": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-        },
-        "from2": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0"
-          }
-        },
-        "fromentries": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
-          "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ=="
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "dev": true,
+          "optional": true
         },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+          "dev": true,
+          "optional": true
         },
         "fs-extra": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -8226,6 +6736,8 @@
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
           "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -8240,531 +6752,23 @@
             "through2": "^2.0.3"
           }
         },
-        "fs-write-stream-atomic": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
-          }
-        },
         "fs.realpath": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "fsevents": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-          "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1",
-            "node-pre-gyp": "*"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "chownr": {
-              "version": "1.1.3",
-              "bundled": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "debug": {
-              "version": "3.2.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "deep-extend": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "detect-libc": {
-              "version": "1.0.3",
-              "bundled": true,
-              "optional": true
-            },
-            "fs-minipass": {
-              "version": "1.2.7",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.6.0"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "iconv-lite": {
-              "version": "0.4.24",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "ignore-walk": {
-              "version": "3.0.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "bundled": true,
-              "optional": true
-            },
-            "ini": {
-              "version": "1.3.5",
-              "bundled": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "optional": true
-            },
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            },
-            "minizlib": {
-              "version": "1.3.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.9.0"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "needle": {
-              "version": "2.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "debug": "^3.2.6",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-              }
-            },
-            "node-pre-gyp": {
-              "version": "0.14.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.1",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.2.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4.4.2"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "npm-normalize-package-bin": "^1.0.1"
-              }
-            },
-            "npm-normalize-package-bin": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "npm-packlist": {
-              "version": "1.4.7",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "rimraf": {
-              "version": "2.7.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true,
-              "optional": true
-            },
-            "semver": {
-              "version": "5.7.1",
-              "bundled": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "4.4.13",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.8.6",
-                "minizlib": "^1.2.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.3"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "wide-align": {
-              "version": "1.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "string-width": "^1.0.2 || 2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "yallist": {
-              "version": "3.1.1",
-              "bundled": true,
-              "optional": true
-            }
-          }
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "dev": true
         },
         "functional-red-black-tree": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-        },
-        "generic-pool": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz",
-          "integrity": "sha1-+XGN7agvoSXtXEPjQcmiFadm2aM="
-        },
-        "gensync": {
-          "version": "1.0.0-beta.1",
-          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-          "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+          "dev": true
         },
         "get-caller-file": {
           "version": "1.0.3",
@@ -8772,15 +6776,12 @@
           "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
-        "get-own-enumerable-property-symbols": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-          "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
-        },
         "get-stream": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -8788,12 +6789,14 @@
         "get-value": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+          "dev": true
         },
         "getpass": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -8802,6 +6805,7 @@
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -8815,6 +6819,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
@@ -8824,6 +6829,7 @@
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
               "requires": {
                 "is-extglob": "^2.1.0"
               }
@@ -8866,6 +6872,7 @@
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
           "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+          "dev": true,
           "requires": {
             "min-document": "^2.19.0",
             "process": "~0.5.1"
@@ -8875,6 +6882,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "dev": true,
           "requires": {
             "global-prefix": "^1.0.1",
             "is-windows": "^1.0.1",
@@ -8885,6 +6893,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
           "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+          "dev": true,
           "requires": {
             "expand-tilde": "^2.0.2",
             "homedir-polyfill": "^1.0.1",
@@ -8912,6 +6921,8 @@
           "version": "9.6.0",
           "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
           "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@sindresorhus/is": "^0.14.0",
             "@szmarczak/http-timer": "^1.1.2",
@@ -8929,17 +6940,15 @@
         "graceful-fs": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "dev": true
         },
         "graceful-readlink": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-        },
-        "growl": {
-          "version": "1.10.5",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+          "dev": true,
+          "optional": true
         },
         "gulp": {
           "version": "4.0.2",
@@ -8993,12 +7002,14 @@
         "har-schema": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
         },
         "har-validator": {
           "version": "5.1.3",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
           "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "dev": true,
           "requires": {
             "ajv": "^6.5.5",
             "har-schema": "^2.0.0"
@@ -9008,6 +7019,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -9016,29 +7028,30 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
         "has-symbol-support-x": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-          "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+          "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+          "dev": true,
+          "optional": true
         },
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "has-to-string-tag-x": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "has-symbol-support-x": "^1.4.1"
           }
@@ -9047,6 +7060,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "dev": true,
           "requires": {
             "get-value": "^2.0.6",
             "has-values": "^1.0.0",
@@ -9057,6 +7071,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "kind-of": "^4.0.0"
@@ -9066,6 +7081,7 @@
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -9076,6 +7092,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -9085,25 +7102,10 @@
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
           "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.1"
-          }
-        },
-        "hasha": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
-          "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
-          "requires": {
-            "is-stream": "^2.0.0",
-            "type-fest": "^0.8.0"
-          },
-          "dependencies": {
-            "is-stream": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-              "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-            }
           }
         },
         "hdkey": {
@@ -9118,11 +7120,6 @@
             "secp256k1": "^3.0.1"
           }
         },
-        "he": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-          "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-        },
         "heap": {
           "version": "0.2.6",
           "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
@@ -9133,6 +7130,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+          "dev": true,
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -9153,6 +7151,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+          "dev": true,
           "requires": {
             "parse-passwd": "^1.0.0"
           }
@@ -9160,22 +7159,22 @@
         "hosted-git-info": {
           "version": "2.8.5",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-          "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
-        },
-        "html-escaper": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-          "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig=="
+          "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+          "dev": true
         },
         "http-cache-semantics": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-          "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+          "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+          "dev": true,
+          "optional": true
         },
         "http-errors": {
           "version": "1.7.2",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -9187,161 +7186,35 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true,
+              "optional": true
             }
           }
         },
         "http-https": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-          "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
+          "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
             "sshpk": "^1.7.0"
           }
         },
-        "https-browserify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-          "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
-        },
-        "humanize": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
-          "integrity": "sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ="
-        },
-        "husky": {
-          "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/husky/-/husky-4.0.10.tgz",
-          "integrity": "sha512-Ptm4k2DqOwxeK/kzu5RaJmNRoGvESrgDXObFcZ8aJZcyXyMBHhM2FqZj6zYKdetadmP3wCwxEHCBuB9xGlRp8A==",
-          "requires": {
-            "chalk": "^3.0.0",
-            "ci-info": "^2.0.0",
-            "cosmiconfig": "^6.0.0",
-            "opencollective-postinstall": "^2.0.2",
-            "pkg-dir": "^4.2.0",
-            "please-upgrade-node": "^3.2.0",
-            "slash": "^3.0.0",
-            "which-pm-runs": "^1.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-              "requires": {
-                "@types/color-name": "^1.1.1",
-                "color-convert": "^2.0.1"
-              }
-            },
-            "chalk": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-            },
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-            },
-            "locate-path": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-              "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-              "requires": {
-                "p-locate": "^4.1.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-              "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-              "requires": {
-                "p-limit": "^2.2.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-              "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-            },
-            "pkg-dir": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-              "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-              "requires": {
-                "find-up": "^4.0.0"
-              }
-            },
-            "slash": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-              "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-            },
-            "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
         "iconv-lite": {
           "version": "0.4.24",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -9350,6 +7223,8 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
           "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "punycode": "2.1.0"
           },
@@ -9357,120 +7232,29 @@
             "punycode": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-              "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+              "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+              "dev": true,
+              "optional": true
             }
           }
         },
         "ieee754": {
           "version": "1.1.13",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-        },
-        "iferr": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+          "dev": true
         },
         "immediate": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
-        },
-        "import-fresh": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-          "requires": {
-            "parent-module": "^1.0.0",
-            "resolve-from": "^4.0.0"
-          }
-        },
-        "import-local": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-          "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-          "requires": {
-            "pkg-dir": "^3.0.0",
-            "resolve-cwd": "^2.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            },
-            "pkg-dir": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-              "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-              "requires": {
-                "find-up": "^3.0.0"
-              }
-            }
-          }
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-        },
-        "infer-owner": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -9479,115 +7263,20 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-        },
-        "inquirer": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-          "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.15",
-            "mute-stream": "0.0.8",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.5.3",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-            },
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-            },
-            "lodash": {
-              "version": "4.17.15",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-            },
-            "string-width": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-              "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-              },
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "6.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                  "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                  "requires": {
-                    "ansi-regex": "^5.0.0"
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                  "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-                }
-              }
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "dev": true
         },
         "interpret": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+          "dev": true
         },
         "invariant": {
           "version": "2.2.4",
@@ -9607,7 +7296,9 @@
         "ipaddr.js": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+          "dev": true,
+          "optional": true
         },
         "is-absolute": {
           "version": "1.0.0",
@@ -9623,6 +7314,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -9631,6 +7323,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -9646,12 +7339,14 @@
         "is-arrayish": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
         },
         "is-binary-path": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
           "requires": {
             "binary-extensions": "^1.0.0"
           }
@@ -9659,17 +7354,20 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -9678,6 +7376,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -9687,12 +7386,14 @@
         "is-date-object": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-          "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+          "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+          "dev": true
         },
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -9702,19 +7403,22 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "dev": true
         },
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
@@ -9735,6 +7439,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9742,12 +7447,14 @@
         "is-function": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-          "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+          "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -9755,12 +7462,15 @@
         "is-hex-prefixed": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+          "dev": true
         },
         "is-natural-number": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-          "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+          "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+          "dev": true,
+          "optional": true
         },
         "is-negated-glob": {
           "version": "1.0.0",
@@ -9772,6 +7482,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -9780,60 +7491,44 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
             }
           }
         },
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-        },
         "is-object": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-          "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
-        },
-        "is-observable": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-          "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-          "requires": {
-            "symbol-observable": "^1.1.0"
-          }
+          "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+          "dev": true,
+          "optional": true
         },
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+          "dev": true,
+          "optional": true
         },
         "is-plain-object": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
           "requires": {
             "isobject": "^3.0.1"
           }
-        },
-        "is-promise": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-          "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
-        },
-        "is-regexp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-          "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
         },
         "is-relative": {
           "version": "1.0.0",
@@ -9847,22 +7542,21 @@
         "is-retry-allowed": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+          "dev": true,
+          "optional": true
         },
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "is-string": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-          "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
         },
         "is-symbol": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -9870,7 +7564,8 @@
         "is-typedarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true
         },
         "is-unc-path": {
           "version": "1.0.0",
@@ -9896,12 +7591,8 @@
         "is-windows": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-        },
-        "is-wsl": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "dev": true
         },
         "isarray": {
           "version": "0.0.1",
@@ -9912,198 +7603,30 @@
         "isexe": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-        },
-        "istanbul-lib-coverage": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg=="
-        },
-        "istanbul-lib-hook": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-          "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-          "requires": {
-            "append-transform": "^2.0.0"
-          }
-        },
-        "istanbul-lib-instrument": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.0.tgz",
-          "integrity": "sha512-Nm4wVHdo7ZXSG30KjZ2Wl5SU/Bw7bDx1PdaiIFzEStdjs0H12mOTncn1GVYuqQSaZxpg87VGBRsVRPGD2cD1AQ==",
-          "requires": {
-            "@babel/core": "^7.7.5",
-            "@babel/parser": "^7.7.5",
-            "@babel/template": "^7.7.4",
-            "@babel/traverse": "^7.7.4",
-            "@istanbuljs/schema": "^0.1.2",
-            "istanbul-lib-coverage": "^3.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
-          }
-        },
-        "istanbul-lib-processinfo": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-          "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
-          "requires": {
-            "archy": "^1.0.0",
-            "cross-spawn": "^7.0.0",
-            "istanbul-lib-coverage": "^3.0.0-alpha.1",
-            "make-dir": "^3.0.0",
-            "p-map": "^3.0.0",
-            "rimraf": "^3.0.0",
-            "uuid": "^3.3.3"
-          },
-          "dependencies": {
-            "make-dir": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-              "requires": {
-                "semver": "^6.0.0"
-              }
-            },
-            "p-map": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-              "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-              "requires": {
-                "aggregate-error": "^3.0.0"
-              }
-            },
-            "rimraf": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-          "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
-          "requires": {
-            "istanbul-lib-coverage": "^3.0.0",
-            "make-dir": "^3.0.0",
-            "supports-color": "^7.1.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-            },
-            "make-dir": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-              "requires": {
-                "semver": "^6.0.0"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            },
-            "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-          "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
-          "requires": {
-            "debug": "^4.1.1",
-            "istanbul-lib-coverage": "^3.0.0",
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
-          "requires": {
-            "html-escaper": "^2.0.0",
-            "istanbul-lib-report": "^3.0.0"
-          }
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "dev": true
         },
         "isurl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "has-to-string-tag-x": "^1.2.0",
             "is-object": "^1.0.1"
-          }
-        },
-        "jest-worker": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-          "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
-          "requires": {
-            "merge-stream": "^2.0.0",
-            "supports-color": "^6.1.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "js-scrypt": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/js-scrypt/-/js-scrypt-0.2.0.tgz",
-          "integrity": "sha1-emK3AbRhbnCtDN5URiequ5nX/jk=",
-          "requires": {
-            "generic-pool": "~2.0.4"
           }
         },
         "js-sha3": {
@@ -10118,19 +7641,11 @@
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
         "jsbn": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "dev": true
         },
         "jsesc": {
           "version": "0.5.0",
@@ -10141,12 +7656,9 @@
         "json-buffer": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-          "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-        },
-        "json-parse-better-errors": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+          "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+          "dev": true,
+          "optional": true
         },
         "json-rpc-engine": {
           "version": "3.8.0",
@@ -10180,12 +7692,14 @@
         "json-schema": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
@@ -10199,12 +7713,14 @@
         "json-stable-stringify-without-jsonify": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-          "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+          "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+          "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true
         },
         "json5": {
           "version": "0.5.1",
@@ -10216,6 +7732,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -10230,6 +7748,7 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
           "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -10269,6 +7788,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
           "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "json-buffer": "3.0.0"
           }
@@ -10276,15 +7797,8 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-        },
-        "klaw": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-          "requires": {
-            "graceful-fs": "^4.1.9"
-          }
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
         },
         "last-run": {
           "version": "1.1.1",
@@ -10314,11 +7828,6 @@
             "invert-kv": "^1.0.0"
           }
         },
-        "lcov-parse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-          "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A="
-        },
         "lead": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
@@ -10333,11 +7842,6 @@
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
           "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
           "dev": true
-        },
-        "level-concat-iterator": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-          "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
         },
         "level-errors": {
           "version": "2.0.1",
@@ -10480,14 +7984,6 @@
             }
           }
         },
-        "level-supports": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-          "requires": {
-            "xtend": "^4.0.2"
-          }
-        },
         "level-ws": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
@@ -10565,15 +8061,6 @@
             }
           }
         },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
         "liftoff": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
@@ -10588,264 +8075,6 @@
             "object.map": "^1.0.0",
             "rechoir": "^0.6.2",
             "resolve": "^1.1.7"
-          }
-        },
-        "lines-and-columns": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-          "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
-        },
-        "lint-staged": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.0.0.tgz",
-          "integrity": "sha512-/MrZOLMnljjMHakxlRd1Z5Kr8wWWlrWFasye7HaTv5tx56icwzT/STRty8flMKsyzBGTfTa9QszNVPsDS/yOug==",
-          "requires": {
-            "chalk": "^3.0.0",
-            "commander": "^4.0.1",
-            "cosmiconfig": "^6.0.0",
-            "debug": "^4.1.1",
-            "dedent": "^0.7.0",
-            "execa": "^3.4.0",
-            "listr": "^0.14.3",
-            "log-symbols": "^3.0.0",
-            "micromatch": "^4.0.2",
-            "normalize-path": "^3.0.0",
-            "please-upgrade-node": "^3.2.0",
-            "stringify-object": "^3.3.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-              "requires": {
-                "@types/color-name": "^1.1.1",
-                "color-convert": "^2.0.1"
-              }
-            },
-            "braces": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-              "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-              "requires": {
-                "fill-range": "^7.0.1"
-              }
-            },
-            "chalk": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-            },
-            "commander": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-              "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
-            },
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "fill-range": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-              "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-              "requires": {
-                "to-regex-range": "^5.0.1"
-              }
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-            },
-            "is-number": {
-              "version": "7.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-              "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-            },
-            "micromatch": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-              "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-              }
-            },
-            "normalize-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-            },
-            "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            },
-            "to-regex-range": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-              "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-              "requires": {
-                "is-number": "^7.0.0"
-              }
-            }
-          }
-        },
-        "listr": {
-          "version": "0.14.3",
-          "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-          "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
-          "requires": {
-            "@samverschueren/stream-to-observable": "^0.3.0",
-            "is-observable": "^1.1.0",
-            "is-promise": "^2.1.0",
-            "is-stream": "^1.1.0",
-            "listr-silent-renderer": "^1.1.1",
-            "listr-update-renderer": "^0.5.0",
-            "listr-verbose-renderer": "^0.5.0",
-            "p-map": "^2.0.0",
-            "rxjs": "^6.3.3"
-          }
-        },
-        "listr-silent-renderer": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-          "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
-        },
-        "listr-update-renderer": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-          "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-          "requires": {
-            "chalk": "^1.1.3",
-            "cli-truncate": "^0.2.1",
-            "elegant-spinner": "^1.0.1",
-            "figures": "^1.7.0",
-            "indent-string": "^3.0.0",
-            "log-symbols": "^1.0.2",
-            "log-update": "^2.3.0",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "figures": {
-              "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-              "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
-              }
-            },
-            "log-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-              "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-              "requires": {
-                "chalk": "^1.0.0"
-              }
-            }
-          }
-        },
-        "listr-verbose-renderer": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-          "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-          "requires": {
-            "chalk": "^2.4.1",
-            "cli-cursor": "^2.1.0",
-            "date-fns": "^1.27.2",
-            "figures": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "cli-cursor": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-              "requires": {
-                "restore-cursor": "^2.0.0"
-              }
-            },
-            "figures": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-              "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-              "requires": {
-                "escape-string-regexp": "^1.0.5"
-              }
-            },
-            "mimic-fn": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-            },
-            "onetime": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-              "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-              "requires": {
-                "mimic-fn": "^1.0.0"
-              }
-            },
-            "restore-cursor": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-              "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-              "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "load-json-file": {
@@ -10869,190 +8098,11 @@
             }
           }
         },
-        "loader-runner": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-          "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          },
-          "dependencies": {
-            "json5": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-              "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-              "requires": {
-                "minimist": "^1.2.0"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            }
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            }
-          }
-        },
         "lodash": {
           "version": "4.17.14",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
-        },
-        "lodash.flattendeep": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-          "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
-        },
-        "lodash.merge": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-        },
-        "log-driver": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-          "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
-        },
-        "log-symbols": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-          "requires": {
-            "chalk": "^2.4.2"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "log-update": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-          "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "cli-cursor": "^2.0.0",
-            "wrap-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-              "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
-            },
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-            },
-            "cli-cursor": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-              "requires": {
-                "restore-cursor": "^2.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "mimic-fn": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-            },
-            "onetime": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-              "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-              "requires": {
-                "mimic-fn": "^1.0.0"
-              }
-            },
-            "restore-cursor": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-              "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-              "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            },
-            "wrap-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-              "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0"
-              }
-            }
-          }
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+          "dev": true
         },
         "looper": {
           "version": "2.0.0",
@@ -11072,26 +8122,31 @@
         "lowercase-keys": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.1"
+            "yallist": "^3.0.2"
           }
         },
         "ltgt": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-          "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+          "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+          "dev": true
         },
         "make-dir": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "pify": "^3.0.0"
           },
@@ -11099,7 +8154,9 @@
             "pify": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -11112,28 +8169,17 @@
             "kind-of": "^6.0.2"
           }
         },
-        "mamacro": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-          "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
-        },
-        "map-age-cleaner": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-          "requires": {
-            "p-defer": "^1.0.0"
-          }
-        },
         "map-cache": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+          "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
           }
@@ -11177,6 +8223,7 @@
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
           "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+          "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1",
@@ -11186,66 +8233,16 @@
         "media-typer": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-        },
-        "mem": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-          "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
-            "p-is-promise": "^2.0.0"
-          }
-        },
-        "memdown": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
-          "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
-          "requires": {
-            "abstract-leveldown": "~6.2.1",
-            "functional-red-black-tree": "~1.0.1",
-            "immediate": "~3.2.3",
-            "inherits": "~2.0.1",
-            "ltgt": "~2.2.0",
-            "safe-buffer": "~5.2.0"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "6.2.2",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
-              "integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
-              "requires": {
-                "level-concat-iterator": "~2.0.0",
-                "level-supports": "~1.0.0",
-                "xtend": "~4.0.0"
-              }
-            }
-          }
-        },
-        "memory-fs": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
-        },
-        "memorystream": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-          "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
+          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+          "dev": true,
+          "optional": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-        },
-        "merge-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+          "dev": true,
+          "optional": true
         },
         "merkle-patricia-tree": {
           "version": "2.3.2",
@@ -11356,12 +8353,15 @@
         "methods": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "dev": true,
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -11382,6 +8382,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
           "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.0.0",
             "brorand": "^1.0.1"
@@ -11390,35 +8391,37 @@
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true,
+          "optional": true
         },
         "mime-db": {
           "version": "1.43.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.26",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
           "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "dev": true,
           "requires": {
             "mime-db": "1.43.0"
           }
         },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-        },
         "mimic-response": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+          "dev": true,
+          "optional": true
         },
         "min-document": {
           "version": "2.19.0",
           "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
           "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+          "dev": true,
           "requires": {
             "dom-walk": "^0.1.0"
           }
@@ -11426,17 +8429,20 @@
         "minimalistic-assert": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+          "dev": true
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11444,115 +8450,35 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
-          }
-        },
-        "minipass-collect": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-          "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-          "requires": {
-            "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-            }
-          }
-        },
-        "minipass-flush": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-          "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-          "requires": {
-            "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-            }
-          }
-        },
-        "minipass-pipeline": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-          "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
-          "requires": {
-            "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-            }
           }
         },
         "minizlib": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
           "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
-          }
-        },
-        "mississippi": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-          "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
           }
         },
         "mixin-deep": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
           "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+          "dev": true,
           "requires": {
             "for-in": "^1.0.2",
             "is-extendable": "^1.0.1"
@@ -11562,6 +8488,7 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
               }
@@ -11571,406 +8498,32 @@
         "mkdirp": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
+          "dev": true,
+          "optional": true
         },
         "mkdirp-promise": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
           "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "mkdirp": "*"
           }
         },
-        "mocha": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.0.tgz",
-          "integrity": "sha512-CirsOPbO3jU86YKjjMzFLcXIb5YiGLUrjrXFHoJ3e2z9vWiaZVCZQ2+gtRGMPWF+nFhN6AWwLM/juzAQ6KRkbA==",
-          "requires": {
-            "ansi-colors": "3.2.3",
-            "browser-stdout": "1.3.1",
-            "chokidar": "3.3.0",
-            "debug": "3.2.6",
-            "diff": "3.5.0",
-            "escape-string-regexp": "1.0.5",
-            "find-up": "3.0.0",
-            "glob": "7.1.3",
-            "growl": "1.10.5",
-            "he": "1.2.0",
-            "js-yaml": "3.13.1",
-            "log-symbols": "2.2.0",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "ms": "2.1.1",
-            "node-environment-flags": "1.0.6",
-            "object.assign": "4.1.0",
-            "strip-json-comments": "2.0.1",
-            "supports-color": "6.0.0",
-            "which": "1.3.1",
-            "wide-align": "1.1.3",
-            "yargs": "13.3.0",
-            "yargs-parser": "13.1.1",
-            "yargs-unparser": "1.6.0"
-          },
-          "dependencies": {
-            "ansi-colors": {
-              "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-              "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
-            },
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-            },
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "anymatch": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-              "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-              "requires": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-              }
-            },
-            "binary-extensions": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-              "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
-            },
-            "braces": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-              "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-              "requires": {
-                "fill-range": "^7.0.1"
-              }
-            },
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "chokidar": {
-              "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-              "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
-              "requires": {
-                "anymatch": "~3.1.1",
-                "braces": "~3.0.2",
-                "fsevents": "~2.1.1",
-                "glob-parent": "~5.1.0",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.2.0"
-              }
-            },
-            "cliui": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-              "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-              "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
-              }
-            },
-            "emoji-regex": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-            },
-            "fill-range": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-              "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-              "requires": {
-                "to-regex-range": "^5.0.1"
-              }
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "fsevents": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-              "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-              "optional": true
-            },
-            "get-caller-file": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-            },
-            "glob": {
-              "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "glob-parent": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-              "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-              "requires": {
-                "is-glob": "^4.0.1"
-              }
-            },
-            "is-binary-path": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-              "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-              "requires": {
-                "binary-extensions": "^2.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "is-number": {
-              "version": "7.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-              "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "log-symbols": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-              "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-              "requires": {
-                "chalk": "^2.0.1"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-            },
-            "normalize-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-              "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            },
-            "readdirp": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-              "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
-              "requires": {
-                "picomatch": "^2.0.4"
-              }
-            },
-            "require-main-filename": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-            },
-            "supports-color": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-              "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            },
-            "to-regex-range": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-              "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-              "requires": {
-                "is-number": "^7.0.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-            },
-            "yargs": {
-              "version": "13.3.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-              "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-              "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.1"
-              }
-            },
-            "yargs-parser": {
-              "version": "13.1.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-              "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
-        },
-        "mocha-lcov-reporter": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
-          "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q="
-        },
         "mock-fs": {
           "version": "4.10.4",
           "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.4.tgz",
-          "integrity": "sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ=="
-        },
-        "move-concurrently": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-          "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            }
-          }
+          "integrity": "sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ==",
+          "dev": true,
+          "optional": true
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "mute-stdout": {
           "version": "1.0.1",
@@ -11978,25 +8531,24 @@
           "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
           "dev": true
         },
-        "mute-stream": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-        },
         "nan": {
           "version": "2.13.2",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "dev": true
         },
         "nano-json-stream-parser": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
-          "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+          "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
+          "dev": true,
+          "optional": true
         },
         "nanomatch": {
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
           "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -12011,46 +8563,18 @@
             "to-regex": "^3.0.1"
           }
         },
-        "natural-compare": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-        },
         "negotiator": {
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-        },
-        "neo-async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+          "dev": true,
+          "optional": true
         },
         "next-tick": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-        },
-        "nice-try": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-        },
-        "node-environment-flags": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-          "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-          "requires": {
-            "object.getownpropertydescriptors": "^2.0.3",
-            "semver": "^5.7.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-            }
-          }
+          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+          "dev": true
         },
         "node-fetch": {
           "version": "2.1.2",
@@ -12058,96 +8582,11 @@
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         },
-        "node-libs-browser": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
-          "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
-          "requires": {
-            "assert": "^1.1.1",
-            "browserify-zlib": "^0.2.0",
-            "buffer": "^4.3.0",
-            "console-browserify": "^1.1.0",
-            "constants-browserify": "^1.0.0",
-            "crypto-browserify": "^3.11.0",
-            "domain-browser": "^1.1.1",
-            "events": "^3.0.0",
-            "https-browserify": "^1.0.0",
-            "os-browserify": "^0.3.0",
-            "path-browserify": "0.0.1",
-            "process": "^0.11.10",
-            "punycode": "^1.2.4",
-            "querystring-es3": "^0.2.0",
-            "readable-stream": "^2.3.3",
-            "stream-browserify": "^2.0.1",
-            "stream-http": "^2.7.2",
-            "string_decoder": "^1.0.0",
-            "timers-browserify": "^2.0.4",
-            "tty-browserify": "0.0.0",
-            "url": "^0.11.0",
-            "util": "^0.11.0",
-            "vm-browserify": "^1.0.1"
-          },
-          "dependencies": {
-            "buffer": {
-              "version": "4.9.2",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-              "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-              "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "process": {
-              "version": "0.11.10",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-              "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-            },
-            "string_decoder": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-              "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-              "requires": {
-                "safe-buffer": "~5.2.0"
-              }
-            },
-            "util": {
-              "version": "0.11.1",
-              "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-              "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            }
-          }
-        },
-        "node-preload": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
-          "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
-          "requires": {
-            "process-on-spawn": "^1.0.0"
-          }
-        },
         "normalize-package-data": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
           "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
@@ -12158,7 +8597,8 @@
             "semver": {
               "version": "5.7.1",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
             }
           }
         },
@@ -12166,6 +8606,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -12173,7 +8614,9 @@
         "normalize-url": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+          "dev": true,
+          "optional": true
         },
         "now-and-later": {
           "version": "2.0.1",
@@ -12184,23 +8627,18 @@
             "once": "^1.3.2"
           }
         },
-        "npm-run-path": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
         },
         "number-to-bn": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -12209,260 +8647,29 @@
             "bn.js": {
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-            }
-          }
-        },
-        "nyc": {
-          "version": "15.0.0",
-          "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
-          "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
-          "requires": {
-            "@istanbuljs/load-nyc-config": "^1.0.0",
-            "@istanbuljs/schema": "^0.1.2",
-            "caching-transform": "^4.0.0",
-            "convert-source-map": "^1.7.0",
-            "decamelize": "^1.2.0",
-            "find-cache-dir": "^3.2.0",
-            "find-up": "^4.1.0",
-            "foreground-child": "^2.0.0",
-            "glob": "^7.1.6",
-            "istanbul-lib-coverage": "^3.0.0",
-            "istanbul-lib-hook": "^3.0.0",
-            "istanbul-lib-instrument": "^4.0.0",
-            "istanbul-lib-processinfo": "^2.0.2",
-            "istanbul-lib-report": "^3.0.0",
-            "istanbul-lib-source-maps": "^4.0.0",
-            "istanbul-reports": "^3.0.0",
-            "js-yaml": "^3.13.1",
-            "make-dir": "^3.0.0",
-            "node-preload": "^0.2.0",
-            "p-map": "^3.0.0",
-            "process-on-spawn": "^1.0.0",
-            "resolve-from": "^5.0.0",
-            "rimraf": "^3.0.0",
-            "signal-exit": "^3.0.2",
-            "spawn-wrap": "^2.0.0",
-            "test-exclude": "^6.0.0",
-            "uuid": "^3.3.3",
-            "yargs": "^15.0.2"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-            },
-            "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-              "requires": {
-                "@types/color-name": "^1.1.1",
-                "color-convert": "^2.0.1"
-              }
-            },
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-            },
-            "cliui": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-              "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-              "requires": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^6.2.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-            },
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "get-caller-file": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-            },
-            "locate-path": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-              "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-              "requires": {
-                "p-locate": "^4.1.0"
-              }
-            },
-            "make-dir": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-              "requires": {
-                "semver": "^6.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-              "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-              "requires": {
-                "p-limit": "^2.2.0"
-              }
-            },
-            "p-map": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-              "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-              "requires": {
-                "aggregate-error": "^3.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-              "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-            },
-            "require-main-filename": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-            },
-            "resolve-from": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-              "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-            },
-            "rimraf": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            },
-            "string-width": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-              "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-            },
-            "wrap-ansi": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-              "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-              "requires": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-            },
-            "yargs": {
-              "version": "15.1.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-              "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
-              "requires": {
-                "cliui": "^6.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^4.1.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^4.2.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^16.1.0"
-              }
-            },
-            "yargs-parser": {
-              "version": "16.1.0",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-              "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+              "dev": true,
+              "optional": true
             }
           }
         },
         "oauth-sign": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
             "define-property": "^0.2.5",
@@ -12473,6 +8680,7 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -12481,6 +8689,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -12490,7 +8699,8 @@
         "object-inspect": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+          "dev": true
         },
         "object-is": {
           "version": "1.0.2",
@@ -12508,6 +8718,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "dev": true,
           "requires": {
             "isobject": "^3.0.0"
           }
@@ -12516,6 +8727,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
           "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
             "function-bind": "^1.1.1",
@@ -12526,7 +8738,8 @@
             "object-keys": {
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-              "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+              "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+              "dev": true
             }
           }
         },
@@ -12546,6 +8759,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
           "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.17.0-next.1"
@@ -12565,6 +8779,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "dev": true,
           "requires": {
             "isobject": "^3.0.1"
           }
@@ -12579,21 +8794,12 @@
             "make-iterator": "^1.0.0"
           }
         },
-        "object.values": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-          "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3"
-          }
-        },
         "oboe": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -12602,6 +8808,8 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -12610,34 +8818,9 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
           "requires": {
             "wrappy": "1"
-          }
-        },
-        "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        },
-        "opencollective-postinstall": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-          "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
           }
         },
         "ordered-read-streams": {
@@ -12648,11 +8831,6 @@
           "requires": {
             "readable-stream": "^2.0.1"
           }
-        },
-        "os-browserify": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-          "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -12672,100 +8850,39 @@
         "os-tmpdir": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "dev": true
         },
         "p-cancelable": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
-        },
-        "p-defer": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+          "dev": true,
+          "optional": true
         },
         "p-finally": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-        },
-        "p-is-promise": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "dev": true,
+          "optional": true
         },
         "p-timeout": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        },
-        "package-hash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-          "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-          "requires": {
-            "graceful-fs": "^4.1.15",
-            "hasha": "^5.0.0",
-            "lodash.flattendeep": "^4.4.0",
-            "release-zalgo": "^1.0.0"
-          }
-        },
-        "pako": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-        },
-        "parallel-transform": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
-          "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
-          "requires": {
-            "cyclist": "^1.0.1",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.1.5"
-          }
-        },
-        "parent-module": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-          "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-          "requires": {
-            "callsites": "^3.0.0"
           }
         },
         "parse-asn1": {
           "version": "5.1.5",
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
           "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "asn1.js": "^4.0.0",
             "browserify-aes": "^1.0.0",
@@ -12789,12 +8906,14 @@
         "parse-headers": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-          "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+          "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -12808,27 +8927,27 @@
         "parse-passwd": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-          "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+          "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+          "dev": true
         },
         "parseurl": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+          "dev": true,
+          "optional": true
         },
         "pascalcase": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-        },
-        "path-browserify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-          "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+          "dev": true
         },
         "path-dirname": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-          "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+          "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
@@ -12842,17 +8961,14 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
         },
         "path-root": {
           "version": "0.1.1",
@@ -12872,7 +8988,9 @@
         "path-to-regexp": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true,
+          "optional": true
         },
         "path-type": {
           "version": "1.1.0",
@@ -12897,6 +9015,7 @@
           "version": "3.0.17",
           "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
           "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+          "dev": true,
           "requires": {
             "create-hash": "^1.1.2",
             "create-hmac": "^1.1.4",
@@ -12908,86 +9027,36 @@
         "pend": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-          "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+          "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
-        "picomatch": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-          "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
-          }
-        },
-        "pkg-dir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "requires": {
-            "find-up": "^2.1.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
-            }
-          }
-        },
-        "please-upgrade-node": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-          "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-          "requires": {
-            "semver-compare": "^1.0.0"
-          }
-        },
-        "portfinder": {
-          "version": "1.0.25",
-          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-          "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
-          "requires": {
-            "async": "^2.6.2",
-            "debug": "^3.1.1",
-            "mkdirp": "^0.5.1"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            }
           }
         },
         "posix-character-classes": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+          "dev": true
         },
         "precond": {
           "version": "0.2.3",
@@ -12995,20 +9064,12 @@
           "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
           "dev": true
         },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-        },
         "prepend-http": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-        },
-        "prettier": {
-          "version": "1.19.1",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true,
+          "optional": true
         },
         "pretty-hrtime": {
           "version": "1.0.3",
@@ -13025,30 +9086,14 @@
         "process": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+          "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-        },
-        "process-on-spawn": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-          "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
-          "requires": {
-            "fromentries": "^1.2.0"
-          }
-        },
-        "progress": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
-        },
-        "promise-inflight": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "dev": true
         },
         "promise-to-callback": {
           "version": "1.0.0",
@@ -13064,6 +9109,8 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
           "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.9.0"
@@ -13072,7 +9119,8 @@
         "prr": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
@@ -13083,12 +9131,15 @@
         "psl": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-          "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+          "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+          "dev": true
         },
         "public-encrypt": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
           "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "browserify-rsa": "^4.0.0",
@@ -13160,6 +9211,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -13169,6 +9222,7 @@
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
           "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+          "dev": true,
           "requires": {
             "duplexify": "^3.6.0",
             "inherits": "^2.0.3",
@@ -13179,6 +9233,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
               "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+              "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -13189,37 +9244,33 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
         },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true,
+          "optional": true
         },
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
             "strict-uri-encode": "^1.0.0"
           }
         },
-        "querystring": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-        },
-        "querystring-es3": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-          "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
-        },
         "randombytes": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
           "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.0"
           }
@@ -13228,6 +9279,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
           "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "randombytes": "^2.0.5",
             "safe-buffer": "^5.1.0"
@@ -13236,12 +9289,16 @@
         "range-parser": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+          "dev": true,
+          "optional": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -13274,6 +9331,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -13287,17 +9345,20 @@
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
             },
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -13308,6 +9369,7 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "micromatch": "^3.1.10",
@@ -13332,7 +9394,8 @@
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
         },
         "regenerator-transform": {
           "version": "0.10.1",
@@ -13349,6 +9412,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+          "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
             "safe-regex": "^1.1.0"
@@ -13363,11 +9427,6 @@
             "define-properties": "^1.1.3",
             "es-abstract": "^1.17.0-next.1"
           }
-        },
-        "regexpp": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
         },
         "regexpu-core": {
           "version": "2.0.0",
@@ -13395,14 +9454,6 @@
             "jsesc": "~0.5.0"
           }
         },
-        "release-zalgo": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-          "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-          "requires": {
-            "es6-error": "^4.0.1"
-          }
-        },
         "remove-bom-buffer": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -13427,17 +9478,20 @@
         "remove-trailing-separator": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+          "dev": true
         },
         "repeat-element": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-          "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+          "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+          "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "dev": true
         },
         "repeating": {
           "version": "2.0.1",
@@ -13469,6 +9523,7 @@
           "version": "2.88.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
           "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -13495,19 +9550,16 @@
             "qs": {
               "version": "6.5.2",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+              "dev": true
             }
           }
         },
         "require-directory": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-        },
-        "require-from-string": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
@@ -13519,38 +9571,20 @@
           "version": "1.14.2",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
           "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+          "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
-          }
-        },
-        "resolve-cwd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-          "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-          "requires": {
-            "resolve-from": "^3.0.0"
-          },
-          "dependencies": {
-            "resolve-from": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-              "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-            }
           }
         },
         "resolve-dir": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+          "dev": true,
           "requires": {
             "expand-tilde": "^2.0.0",
             "global-modules": "^1.0.0"
           }
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
         "resolve-options": {
           "version": "1.1.0",
@@ -13564,23 +9598,17 @@
         "resolve-url": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+          "dev": true
         },
         "responselike": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "lowercase-keys": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
           }
         },
         "resumer": {
@@ -13595,12 +9623,14 @@
         "ret": {
           "version": "0.1.15",
           "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -13609,6 +9639,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+          "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1"
@@ -13618,24 +9649,9 @@
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
           "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.1"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "requires": {
-            "is-promise": "^2.1.0"
-          }
-        },
-        "run-queue": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-          "requires": {
-            "aproba": "^1.1.1"
           }
         },
         "rustbn.js": {
@@ -13644,18 +9660,11 @@
           "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
           "dev": true
         },
-        "rxjs": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-          "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
         "safe-buffer": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
         },
         "safe-event-emitter": {
           "version": "1.0.1",
@@ -13670,6 +9679,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "dev": true,
           "requires": {
             "ret": "~0.1.10"
           }
@@ -13677,31 +9687,15 @@
         "safer-buffer": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "schema-utils": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
-          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
-          "requires": {
-            "ajv": "^6.10.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        },
-        "scrypt": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-          "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "nan": "^2.0.8"
-          }
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "dev": true
         },
         "scrypt-js": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "dev": true,
+          "optional": true
         },
         "scrypt.js": {
           "version": "0.3.0",
@@ -13710,7 +9704,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "scrypt": "^6.0.2",
             "scryptsy": "^1.2.1"
           }
         },
@@ -13728,6 +9721,7 @@
           "version": "3.8.0",
           "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
           "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "dev": true,
           "requires": {
             "bindings": "^1.5.0",
             "bip66": "^1.1.5",
@@ -13742,7 +9736,8 @@
             "nan": {
               "version": "2.14.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+              "dev": true
             }
           }
         },
@@ -13756,6 +9751,8 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
           "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "commander": "~2.8.1"
           }
@@ -13765,16 +9762,6 @@
           "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
           "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
-          "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A=="
-        },
-        "semver-compare": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-          "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
         },
         "semver-greatest-satisfied-range": {
           "version": "1.1.0",
@@ -13789,6 +9776,8 @@
           "version": "0.17.1",
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -13809,6 +9798,8 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -13816,26 +9807,27 @@
                 "ms": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
             "ms": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true,
+              "optional": true
             }
           }
-        },
-        "serialize-javascript": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
         },
         "serve-static": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
           "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
@@ -13847,6 +9839,8 @@
           "version": "0.1.12",
           "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
           "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "body-parser": "^1.16.0",
             "cors": "^2.8.1",
@@ -13858,7 +9852,8 @@
         "set-blocking": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true
         },
         "set-immediate-shim": {
           "version": "1.0.1",
@@ -13870,6 +9865,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
           "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -13881,6 +9877,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -13890,17 +9887,22 @@
         "setimmediate": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+          "dev": true,
+          "optional": true
         },
         "setprototypeof": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+          "dev": true,
+          "optional": true
         },
         "sha.js": {
           "version": "2.4.11",
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -13915,33 +9917,19 @@
             "nan": "2.13.2"
           }
         },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
         "simple-concat": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+          "dev": true,
+          "optional": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -13954,35 +9942,11 @@
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
           "dev": true
         },
-        "slice-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            }
-          }
-        },
         "snapdragon": {
           "version": "0.8.2",
           "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+          "dev": true,
           "requires": {
             "base": "^0.11.1",
             "debug": "^2.2.0",
@@ -13998,6 +9962,7 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -14006,6 +9971,7 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -14014,6 +9980,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -14021,12 +9988,14 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             },
             "source-map": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
             }
           }
         },
@@ -14034,6 +10003,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+          "dev": true,
           "requires": {
             "define-property": "^1.0.0",
             "isobject": "^3.0.0",
@@ -14044,6 +10014,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -14052,6 +10023,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -14060,6 +10032,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -14068,6 +10041,7 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -14080,6 +10054,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
           },
@@ -14088,86 +10063,24 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
             }
           }
         },
-        "solc": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/solc/-/solc-0.6.1.tgz",
-          "integrity": "sha512-iKqNYps2p++x8L9sBg7JeAJb7EmW8VJ/2asAzwlLYcUhj86AzuWLe94UTSQHv1SSCCj/x6lya8twvXkZtlTbIQ==",
-          "requires": {
-            "command-exists": "^1.2.8",
-            "commander": "3.0.2",
-            "fs-extra": "^0.30.0",
-            "js-sha3": "0.8.0",
-            "memorystream": "^0.3.1",
-            "require-from-string": "^2.0.0",
-            "semver": "^5.5.0",
-            "tmp": "0.0.33"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-              "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-            },
-            "fs-extra": {
-              "version": "0.30.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-              "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^2.1.0",
-                "klaw": "^1.0.0",
-                "path-is-absolute": "^1.0.0",
-                "rimraf": "^2.2.8"
-              }
-            },
-            "js-sha3": {
-              "version": "0.8.0",
-              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-              "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-            },
-            "jsonfile": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-              "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-              "requires": {
-                "graceful-fs": "^4.1.6"
-              }
-            },
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-            },
-            "tmp": {
-              "version": "0.0.33",
-              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-              "requires": {
-                "os-tmpdir": "~1.0.2"
-              }
-            }
-          }
-        },
-        "source-list-map": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-          "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
           "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+          "dev": true,
           "requires": {
             "atob": "^2.1.2",
             "decode-uri-component": "^0.2.0",
@@ -14180,6 +10093,7 @@
           "version": "0.5.12",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
           "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+          "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -14188,7 +10102,8 @@
         "source-map-url": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+          "dev": true
         },
         "sparkles": {
           "version": "1.0.1",
@@ -14196,54 +10111,11 @@
           "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
           "dev": true
         },
-        "spawn-wrap": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-          "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
-          "requires": {
-            "foreground-child": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "make-dir": "^3.0.0",
-            "rimraf": "^3.0.0",
-            "signal-exit": "^3.0.2",
-            "which": "^2.0.1"
-          },
-          "dependencies": {
-            "make-dir": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-              "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-              "requires": {
-                "semver": "^6.0.0"
-              }
-            },
-            "rimraf": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
-              "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            },
-            "which": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            }
-          }
-        },
         "spdx-correct": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
           "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+          "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -14252,12 +10124,14 @@
         "spdx-exceptions": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-          "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+          "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+          "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -14266,25 +10140,23 @@
         "spdx-license-ids": {
           "version": "3.0.5",
           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+          "dev": true
         },
         "split-string": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
           }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sshpk": {
           "version": "1.16.1",
           "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
           "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+          "dev": true,
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -14300,31 +10172,8 @@
             "tweetnacl": {
               "version": "0.14.5",
               "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-            }
-          }
-        },
-        "ssri": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-          "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
-          "requires": {
-            "figgy-pudding": "^3.5.1",
-            "minipass": "^3.1.1"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+              "dev": true
             }
           }
         },
@@ -14338,6 +10187,7 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "dev": true,
           "requires": {
             "define-property": "^0.2.5",
             "object-copy": "^0.1.0"
@@ -14347,6 +10197,7 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -14356,25 +10207,9 @@
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-        },
-        "stream-browserify": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
-          "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
-          "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "stream-each": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-          "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "stream-shift": "^1.0.0"
-          }
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true,
+          "optional": true
         },
         "stream-exhaust": {
           "version": "1.0.2",
@@ -14382,22 +10217,11 @@
           "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
           "dev": true
         },
-        "stream-http": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-          "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-          "requires": {
-            "builtin-status-codes": "^3.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.3.6",
-            "to-arraybuffer": "^1.0.0",
-            "xtend": "^4.0.0"
-          }
-        },
         "stream-shift": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-          "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+          "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+          "dev": true
         },
         "stream-to-pull-stream": {
           "version": "1.7.3",
@@ -14420,12 +10244,15 @@
         "strict-uri-encode": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14447,6 +10274,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
           "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -14456,6 +10284,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
           "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -14467,20 +10296,11 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
-        "stringify-object": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-          "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-          "requires": {
-            "get-own-enumerable-property-symbols": "^3.0.0",
-            "is-obj": "^1.0.1",
-            "is-regexp": "^1.0.0"
-          }
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14498,37 +10318,26 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
           "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "is-natural-number": "^4.0.1"
           }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-        },
-        "strip-final-newline": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
         },
         "strip-hex-prefix": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
           "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+          "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0"
           }
         },
-        "strip-json-comments": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
-        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         },
         "sver-compat": {
           "version": "1.5.0",
@@ -14544,6 +10353,8 @@
           "version": "0.1.39",
           "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
           "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bluebird": "^3.5.0",
             "buffer": "^5.0.5",
@@ -14562,12 +10373,16 @@
             "get-stream": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+              "dev": true,
+              "optional": true
             },
             "got": {
               "version": "7.1.0",
               "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
               "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "decompress-response": "^3.2.0",
                 "duplexer3": "^0.1.4",
@@ -14588,78 +10403,28 @@
             "p-cancelable": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-              "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+              "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+              "dev": true,
+              "optional": true
             },
             "prepend-http": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+              "dev": true,
+              "optional": true
             },
             "url-parse-lax": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
               "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "prepend-http": "^1.0.1"
               }
             }
           }
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-        },
-        "table": {
-          "version": "5.4.6",
-          "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-          "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-          "requires": {
-            "ajv": "^6.10.2",
-            "lodash": "^4.17.14",
-            "slice-ansi": "^2.1.0",
-            "string-width": "^3.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-            },
-            "emoji-regex": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
-        },
-        "tapable": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
         },
         "tape": {
           "version": "4.13.0",
@@ -14696,6 +10461,8 @@
           "version": "4.4.13",
           "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
           "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -14710,6 +10477,8 @@
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14720,6 +10489,8 @@
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -14730,80 +10501,17 @@
             "xtend": "^4.0.0"
           }
         },
-        "temp": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
-          "integrity": "sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==",
-          "requires": {
-            "rimraf": "~2.6.2"
-          },
-          "dependencies": {
-            "rimraf": {
-              "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "terser": {
-          "version": "4.6.3",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
-          "integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.20.3",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-            }
-          }
-        },
-        "terser-webpack-plugin": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.2.tgz",
-          "integrity": "sha512-SmvB/6gtEPv+CJ88MH5zDOsZdKXPS/Uzv2//e90+wM1IHFUhsguPKEILgzqrM1nQ4acRXN/SV4Obr55SXC+0oA==",
-          "requires": {
-            "cacache": "^13.0.1",
-            "find-cache-dir": "^3.2.0",
-            "jest-worker": "^24.9.0",
-            "schema-utils": "^2.6.1",
-            "serialize-javascript": "^2.1.2",
-            "source-map": "^0.6.1",
-            "terser": "^4.4.3",
-            "webpack-sources": "^1.4.3"
-          }
-        },
-        "test-exclude": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-          "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-          "requires": {
-            "@istanbuljs/schema": "^0.1.2",
-            "glob": "^7.1.4",
-            "minimatch": "^3.0.4"
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-        },
         "through": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
         },
         "through2": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -14828,15 +10536,9 @@
         "timed-out": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-        },
-        "timers-browserify": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-          "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
-          "requires": {
-            "setimmediate": "^1.0.4"
-          }
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+          "dev": true,
+          "optional": true
         },
         "tmp": {
           "version": "0.1.0",
@@ -14857,15 +10559,12 @@
             "is-negated-glob": "^1.0.0"
           }
         },
-        "to-arraybuffer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-          "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
-        },
         "to-buffer": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+          "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+          "dev": true,
+          "optional": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -14877,6 +10576,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -14885,6 +10585,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -14894,12 +10595,15 @@
         "to-readable-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-          "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+          "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+          "dev": true,
+          "optional": true
         },
         "to-regex": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "dev": true,
           "requires": {
             "define-property": "^2.0.2",
             "extend-shallow": "^3.0.2",
@@ -14911,6 +10615,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
@@ -14928,12 +10633,15 @@
         "toidentifier": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-          "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+          "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+          "dev": true,
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -14942,7 +10650,8 @@
             "punycode": {
               "version": "1.4.1",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+              "dev": true
             }
           }
         },
@@ -14952,20 +10661,11 @@
           "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
-        "tslib": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
-        },
-        "tty-browserify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-          "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
-        },
         "tunnel-agent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -14985,25 +10685,15 @@
         "type": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+          "dev": true
         },
         "type-is": {
           "version": "1.6.18",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
@@ -15012,12 +10702,14 @@
         "typedarray": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+          "dev": true
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
           "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
           "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "dev": true,
           "requires": {
             "is-typedarray": "^1.0.0"
           }
@@ -15046,12 +10738,16 @@
         "ultron": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+          "dev": true,
+          "optional": true
         },
         "unbzip2-stream": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
           "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "buffer": "^5.2.1",
             "through": "^2.3.8"
@@ -15066,7 +10762,9 @@
         "underscore": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+          "dev": true,
+          "optional": true
         },
         "undertaker": {
           "version": "1.2.1",
@@ -15095,27 +10793,12 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
           "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+          "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
             "get-value": "^2.0.6",
             "is-extendable": "^0.1.1",
             "set-value": "^2.0.1"
-          }
-        },
-        "unique-filename": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-          "requires": {
-            "unique-slug": "^2.0.0"
-          }
-        },
-        "unique-slug": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-          "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-          "requires": {
-            "imurmurhash": "^0.1.4"
           }
         },
         "unique-stream": {
@@ -15131,7 +10814,9 @@
         "universalify": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true,
+          "optional": true
         },
         "unorm": {
           "version": "1.6.0",
@@ -15142,12 +10827,15 @@
         "unpipe": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+          "dev": true,
+          "optional": true
         },
         "unset-value": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "dev": true,
           "requires": {
             "has-value": "^0.3.1",
             "isobject": "^3.0.0"
@@ -15157,6 +10845,7 @@
               "version": "0.3.1",
               "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "dev": true,
               "requires": {
                 "get-value": "^2.0.3",
                 "has-values": "^0.1.4",
@@ -15167,6 +10856,7 @@
                   "version": "2.1.0",
                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
                   }
@@ -15176,24 +10866,28 @@
             "has-values": {
               "version": "0.1.4",
               "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+              "dev": true
             },
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
             }
           }
         },
         "upath": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-          "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+          "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+          "dev": true
         },
         "uri-js": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
           "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "dev": true,
           "requires": {
             "punycode": "^2.1.0"
           }
@@ -15201,28 +10895,15 @@
         "urix": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-        },
-        "url": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-            }
-          }
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+          "dev": true
         },
         "url-parse-lax": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "prepend-http": "^2.0.0"
           }
@@ -15230,42 +10911,35 @@
         "url-set-query": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-          "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+          "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
+          "dev": true,
+          "optional": true
         },
         "url-to-options": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-          "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+          "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+          "dev": true,
+          "optional": true
         },
         "use": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-          "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+          "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+          "dev": true
         },
         "utf8": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-        },
-        "util": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "requires": {
-            "inherits": "2.0.1"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-            }
-          }
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+          "dev": true,
+          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
         },
         "util.promisify": {
           "version": "1.0.1",
@@ -15282,17 +10956,15 @@
         "utils-merge": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "v8-compile-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-          "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         },
         "v8flags": {
           "version": "3.1.3",
@@ -15307,6 +10979,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+          "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -15321,12 +10994,15 @@
         "vary": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+          "dev": true,
+          "optional": true
         },
         "verror": {
           "version": "1.10.0",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -15387,25 +11063,12 @@
             "vinyl": "^2.0.0"
           }
         },
-        "vm-browserify": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-          "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
-        },
-        "watchpack": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-          "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
-          "requires": {
-            "chokidar": "^2.0.2",
-            "graceful-fs": "^4.1.2",
-            "neo-async": "^2.5.0"
-          }
-        },
         "web3": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.4.tgz",
           "integrity": "sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "^12.6.1",
             "web3-bzz": "1.2.4",
@@ -15420,7 +11083,9 @@
             "@types/node": {
               "version": "12.12.26",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15428,6 +11093,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.4.tgz",
           "integrity": "sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "^10.12.18",
             "got": "9.6.0",
@@ -15438,7 +11105,9 @@
             "@types/node": {
               "version": "10.17.14",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-              "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+              "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15446,6 +11115,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
           "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/bignumber.js": "^5.0.0",
             "@types/bn.js": "^4.11.4",
@@ -15459,7 +11130,9 @@
             "@types/node": {
               "version": "12.12.26",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15467,6 +11140,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
           "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.4",
@@ -15477,6 +11152,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
           "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -15489,6 +11166,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
           "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -15498,6 +11177,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
           "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -15510,6 +11191,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
           "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -15520,6 +11203,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.4.tgz",
           "integrity": "sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core": "1.2.4",
@@ -15540,6 +11225,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
           "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -15549,17 +11236,23 @@
             "@types/node": {
               "version": "10.17.14",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-              "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+              "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
+              "dev": true,
+              "optional": true
             },
             "aes-js": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-              "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+              "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+              "dev": true,
+              "optional": true
             },
             "elliptic": {
               "version": "6.3.3",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
               "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -15571,6 +11264,8 @@
               "version": "4.0.0-beta.3",
               "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
               "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "@types/node": "^10.3.2",
                 "aes-js": "3.0.0",
@@ -15588,6 +11283,8 @@
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
               "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.0"
@@ -15596,17 +11293,23 @@
             "js-sha3": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+              "dev": true,
+              "optional": true
             },
             "setimmediate": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+              "dev": true,
+              "optional": true
             },
             "uuid": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-              "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+              "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15614,6 +11317,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz",
           "integrity": "sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@web3-js/scrypt-shim": "^0.1.0",
             "any-promise": "1.3.0",
@@ -15633,6 +11338,8 @@
               "version": "0.2.7",
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
@@ -15642,7 +11349,9 @@
             "uuid": {
               "version": "3.3.2",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15650,6 +11359,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
           "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.4",
             "underscore": "1.9.1",
@@ -15666,6 +11377,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz",
           "integrity": "sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "eth-ens-namehash": "2.0.8",
             "underscore": "1.9.1",
@@ -15681,6 +11394,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
           "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.4"
@@ -15690,6 +11405,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
           "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "^12.6.1",
             "web3-core": "1.2.4",
@@ -15702,7 +11419,9 @@
             "@types/node": {
               "version": "12.12.26",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+              "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15710,6 +11429,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
           "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "web3-core": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -15978,6 +11699,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
           "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.4",
             "xhr2-cookies": "1.1.0"
@@ -15987,6 +11710,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
           "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -15997,6 +11722,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
           "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "@web3-js/websocket": "^1.0.29",
             "underscore": "1.9.1",
@@ -16007,6 +11734,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.4.tgz",
           "integrity": "sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "web3-core": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -16018,6 +11747,8 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
           "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -16033,553 +11764,14 @@
               "version": "0.2.7",
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "dev": true,
+              "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
                 "xhr-request-promise": "^0.1.2"
               }
             }
-          }
-        },
-        "webpack": {
-          "version": "4.41.5",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
-          "integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
-          "requires": {
-            "@webassemblyjs/ast": "1.8.5",
-            "@webassemblyjs/helper-module-context": "1.8.5",
-            "@webassemblyjs/wasm-edit": "1.8.5",
-            "@webassemblyjs/wasm-parser": "1.8.5",
-            "acorn": "^6.2.1",
-            "ajv": "^6.10.2",
-            "ajv-keywords": "^3.4.1",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^4.1.0",
-            "eslint-scope": "^4.0.3",
-            "json-parse-better-errors": "^1.0.2",
-            "loader-runner": "^2.4.0",
-            "loader-utils": "^1.2.3",
-            "memory-fs": "^0.4.1",
-            "micromatch": "^3.1.10",
-            "mkdirp": "^0.5.1",
-            "neo-async": "^2.6.1",
-            "node-libs-browser": "^2.2.1",
-            "schema-utils": "^1.0.0",
-            "tapable": "^1.1.3",
-            "terser-webpack-plugin": "^1.4.3",
-            "watchpack": "^1.6.0",
-            "webpack-sources": "^1.4.1"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-              "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
-            },
-            "cacache": {
-              "version": "12.0.3",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-              "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
-              "requires": {
-                "bluebird": "^3.5.5",
-                "chownr": "^1.1.1",
-                "figgy-pudding": "^3.5.1",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.1.15",
-                "infer-owner": "^1.0.3",
-                "lru-cache": "^5.1.1",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.3",
-                "ssri": "^6.0.1",
-                "unique-filename": "^1.1.1",
-                "y18n": "^4.0.0"
-              }
-            },
-            "eslint-scope": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-              "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-              "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
-              }
-            },
-            "find-cache-dir": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-              "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-              "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^2.0.0",
-                "pkg-dir": "^3.0.0"
-              }
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "lru-cache": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-              "requires": {
-                "yallist": "^3.0.2"
-              }
-            },
-            "make-dir": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-              "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-              "requires": {
-                "pify": "^4.0.1",
-                "semver": "^5.6.0"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            },
-            "pkg-dir": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-              "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-              "requires": {
-                "find-up": "^3.0.0"
-              }
-            },
-            "schema-utils": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-              "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-              "requires": {
-                "ajv": "^6.1.0",
-                "ajv-errors": "^1.0.0",
-                "ajv-keywords": "^3.1.0"
-              }
-            },
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-            },
-            "ssri": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-              "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-              "requires": {
-                "figgy-pudding": "^3.5.1"
-              }
-            },
-            "terser-webpack-plugin": {
-              "version": "1.4.3",
-              "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-              "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
-              "requires": {
-                "cacache": "^12.0.2",
-                "find-cache-dir": "^2.1.0",
-                "is-wsl": "^1.1.0",
-                "schema-utils": "^1.0.0",
-                "serialize-javascript": "^2.1.2",
-                "source-map": "^0.6.1",
-                "terser": "^4.1.2",
-                "webpack-sources": "^1.4.0",
-                "worker-farm": "^1.7.0"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-            }
-          }
-        },
-        "webpack-bundle-size-analyzer": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/webpack-bundle-size-analyzer/-/webpack-bundle-size-analyzer-3.1.0.tgz",
-          "integrity": "sha512-8WlTT6uuCxZgZYNnCB0pRGukWRGH+Owg+HsqQUe1Zexakdno1eDYO+lE7ihBo9G0aCCZCJa8JWjYr9eLYfZrBA==",
-          "requires": {
-            "commander": "^2.19.0",
-            "filesize": "^3.6.1",
-            "humanize": "0.0.9"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.20.3",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-            }
-          }
-        },
-        "webpack-cli": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
-          "integrity": "sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==",
-          "requires": {
-            "chalk": "2.4.2",
-            "cross-spawn": "6.0.5",
-            "enhanced-resolve": "4.1.0",
-            "findup-sync": "3.0.0",
-            "global-modules": "2.0.0",
-            "import-local": "2.0.0",
-            "interpret": "1.2.0",
-            "loader-utils": "1.2.3",
-            "supports-color": "6.1.0",
-            "v8-compile-cache": "2.0.3",
-            "yargs": "13.2.4"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-            },
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "cliui": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-              "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-              "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
-              }
-            },
-            "cross-spawn": {
-              "version": "6.0.5",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "emoji-regex": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-            },
-            "enhanced-resolve": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-              "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.4.0",
-                "tapable": "^1.0.0"
-              }
-            },
-            "execa": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-              "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-              }
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "get-caller-file": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-            },
-            "global-modules": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-              "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-              "requires": {
-                "global-prefix": "^3.0.0"
-              }
-            },
-            "global-prefix": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-              "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-              "requires": {
-                "ini": "^1.3.5",
-                "kind-of": "^6.0.2",
-                "which": "^1.3.1"
-              }
-            },
-            "invert-kv": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-              "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "lcid": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-              "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-              "requires": {
-                "invert-kv": "^2.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "npm-run-path": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-              "requires": {
-                "path-key": "^2.0.0"
-              }
-            },
-            "os-locale": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-              "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-              "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            },
-            "path-key": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-            },
-            "require-main-filename": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-            },
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-            },
-            "shebang-command": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-              "requires": {
-                "shebang-regex": "^1.0.0"
-              }
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            },
-            "v8-compile-cache": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-              "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w=="
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-            },
-            "yargs": {
-              "version": "13.2.4",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-              "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
-              "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "os-locale": "^3.1.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.0"
-              }
-            },
-            "yargs-parser": {
-              "version": "13.1.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-              "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
-        },
-        "webpack-sources": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-          "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
           }
         },
         "websocket": {
@@ -16622,6 +11814,7 @@
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -16631,32 +11824,6 @@
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
           "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
           "dev": true
-        },
-        "which-pm-runs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-          "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "word-wrap": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
-        },
-        "worker-farm": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-          "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
-          "requires": {
-            "errno": "~0.1.7"
-          }
         },
         "wrap-ansi": {
           "version": "2.1.0",
@@ -16671,41 +11838,15 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "write": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-          "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-          "requires": {
-            "mkdirp": "^0.5.1"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            }
-          }
-        },
-        "write-file-atomic": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
-          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
-          "requires": {
-            "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
-          }
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
         },
         "ws": {
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "async-limiter": "~1.0.0",
             "safe-buffer": "~5.1.0",
@@ -16715,7 +11856,9 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -16723,6 +11866,7 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
           "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+          "dev": true,
           "requires": {
             "global": "~4.3.0",
             "is-function": "^1.0.1",
@@ -16734,6 +11878,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+          "dev": true,
+          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -16748,6 +11894,8 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -16756,6 +11904,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
@@ -16763,12 +11913,15 @@
         "xmlhttprequest": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-          "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+          "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+          "dev": true,
+          "optional": true
         },
         "xtend": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+          "dev": true
         },
         "y18n": {
           "version": "3.2.1",
@@ -16779,20 +11932,14 @@
         "yaeti": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-        },
-        "yaml": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
-          "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
-          "requires": {
-            "@babel/runtime": "^7.6.3"
-          }
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
         },
         "yargs": {
           "version": "7.1.0",
@@ -16824,182 +11971,12 @@
             "camelcase": "^3.0.0"
           }
         },
-        "yargs-unparser": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-          "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
-          "requires": {
-            "flat": "^4.1.0",
-            "lodash": "^4.17.15",
-            "yargs": "^13.3.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-            },
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-            },
-            "cliui": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-              "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-              "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
-              }
-            },
-            "emoji-regex": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "get-caller-file": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "lodash": {
-              "version": "4.17.15",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-            },
-            "p-limit": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-              "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            },
-            "require-main-filename": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-            },
-            "yargs": {
-              "version": "13.3.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-              "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-              "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.1"
-              }
-            },
-            "yargs-parser": {
-              "version": "13.1.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-              "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
-        },
         "yauzl": {
           "version": "2.10.0",
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
           "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+          "dev": true,
+          "optional": true,
           "requires": {
             "buffer-crc32": "~0.2.3",
             "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node cli.js",
     "build": "webpack-cli --config ./webpack/webpack.node.config.js",
     "docker": "docker build -t trufflesuite/ganache-cli . && docker run -p 8545:8545 trufflesuite/ganache-cli",
-    "prepublishOnly": "npm run build && export NPM_CONFIG_OTP=$(node ./scripts/release.js)",
+    "prepublishOnly": "npm run build && export NPM_CONFIG_OTP=$(node ./scripts/generate-otp.js)",
     "releaseNotes": "npx semantic-release --dry-run"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "scrypt": "6.0.3",
     "sha3": "1.2.2",
     "shebang-loader": "0.0.1",
-    "webpack": "^4.18.0",
+    "webpack": "4.43.0",
     "webpack-cli": "3.1.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node cli.js",
     "build": "webpack-cli --config ./webpack/webpack.node.config.js",
     "docker": "docker build -t trufflesuite/ganache-cli . && docker run -p 8545:8545 trufflesuite/ganache-cli",
-    "prepublishOnly": "npm run build && export NPM_CONFIG_OTP=$(node ./scripts/generate-otp.js)",
+    "otp": "node ./scripts/generate-otp.js",
     "releaseNotes": "npx semantic-release --dry-run"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "on-build-webpack": "^0.1.0",
     "prepend-file": "^1.3.1",
     "scrypt": "6.0.3",
-    "semantic-release": "^17.0.7",
+    "semantic-release": "^17.1.1",
     "sha3": "1.2.2",
     "shebang-loader": "0.0.1",
     "thirty-two": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node cli.js",
     "build": "webpack-cli --config ./webpack/webpack.node.config.js",
     "docker": "docker build -t trufflesuite/ganache-cli . && docker run -p 8545:8545 trufflesuite/ganache-cli",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && export NPM_CONFIG_OTP=$(node ./scripts/release.js)",
     "releaseNotes": "npx semantic-release --dry-run"
   },
   "dependencies": {
@@ -26,12 +26,14 @@
     "ganache-core": "2.10.2",
     "js-scrypt": "0.2.0",
     "node-loader": "^0.6.0",
+    "notp": "2.0.3",
     "on-build-webpack": "^0.1.0",
     "prepend-file": "^1.3.1",
     "scrypt": "6.0.3",
     "semantic-release": "^17.0.7",
     "sha3": "1.2.2",
     "shebang-loader": "0.0.1",
+    "thirty-two": "1.0.2",
     "webpack": "4.43.0",
     "webpack-cli": "3.1.0"
   },
@@ -47,7 +49,10 @@
     "branches": [
       "+([0-9])?(.{+([0-9]),x}).x",
       "master",
-      {"name": "beta", "prerelease": true}
+      {
+        "name": "beta",
+        "prerelease": true
+      }
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ethereumjs-util"
   ],
   "devDependencies": {
+    "@semantic-release/git": "^9.0.0",
     "ganache-core": "2.11.0-beta.0",
     "js-scrypt": "0.2.0",
     "node-loader": "^0.6.0",
@@ -53,6 +54,19 @@
         "name": "beta",
         "prerelease": true
       }
+    ],
+    "plugins": [
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "package.json",
+            "package-lock.json",
+            "npm-shrinkwrap.json"
+          ],
+          "message": "${nextRelease.version}\n\n${nextRelease.notes}"
+        }
+      ]
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ganache-cli",
-  "version": "6.9.1",
+  "version": "6.10.0-beta.2",
   "bin": {
     "ganache-cli": "cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "node cli.js",
     "build": "webpack-cli --config ./webpack/webpack.node.config.js",
     "docker": "docker build -t trufflesuite/ganache-cli . && docker run -p 8545:8545 trufflesuite/ganache-cli",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "releaseNotes": "npx semantic-release --dry-run"
   },
   "dependencies": {
     "ethereumjs-util": "6.1.0",
@@ -28,6 +29,7 @@
     "on-build-webpack": "^0.1.0",
     "prepend-file": "^1.3.1",
     "scrypt": "6.0.3",
+    "semantic-release": "^17.0.7",
     "sha3": "1.2.2",
     "shebang-loader": "0.0.1",
     "webpack": "4.43.0",
@@ -40,5 +42,12 @@
     "type": "git",
     "url": "https://github.com/trufflesuite/ganache-cli"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "master",
+      {"name": "beta", "prerelease": true}
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "webpack": "4.43.0",
     "webpack-cli": "3.1.0"
   },
-  "optionalDependencies": {
-    "deasync": "0.1.20"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/ganache-cli"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "webpack": "^4.18.0",
     "webpack-cli": "3.1.0"
   },
+  "optionalDependencies": {
+    "deasync": "0.1.20"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/ganache-cli"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "devDependencies": {
     "@semantic-release/git": "^9.0.0",
-    "ganache-core": "2.11.0-beta.0",
+    "ganache-core": "2.11.2",
     "js-scrypt": "0.2.0",
     "node-loader": "^0.6.0",
     "notp": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "webpack": "4.43.0",
     "webpack-cli": "3.1.0"
   },
+  "optionalDependencies": {
+    "scrypt": "6.0.3"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/ganache-cli"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ethereumjs-util"
   ],
   "devDependencies": {
-    "ganache-core": "2.10.2",
+    "ganache-core": "2.11.0-beta.0",
     "js-scrypt": "0.2.0",
     "node-loader": "^0.6.0",
     "notp": "2.0.3",

--- a/scripts/generate-otp.js
+++ b/scripts/generate-otp.js
@@ -8,8 +8,8 @@ process.env.NODE_ENV = "test";
 const b32 = require("thirty-two");
 const notp = require("notp");
 const bin = b32.decode(process.env.NPM_OTP_KEY);
-// generate a code 5 seconds in the future
-// 5 seconds is arbitrary, and may need to be tweaked if
+// generate a code 1 seconds in the future
+// 1 seconds is arbitrary, and may need to be tweaked if
 // the release process is discovered to be too fast or too slow.
 const timeOffset = 1000;
 const now = Date.now();

--- a/scripts/generate-otp.js
+++ b/scripts/generate-otp.js
@@ -1,0 +1,15 @@
+// we want to generate a TOTP in the _future_, and the `notp`
+// library doesn't let us do that unless we set `NODE_ENV = "test"`
+process.env.NODE_ENV = "test";
+
+const b32 = require("thirty-two");
+const notp = require("notp");
+const bin = b32.decode(process.env.NPM_OTP_KEY);
+// generate a code 5 seconds in the future
+// 5 seconds is arbitrary, and may need to be tweaked if
+// the release process is discovered to be too fast or too slow.
+const timeOffset = 5000;
+const now = Date.now();
+const time = now + timeOffset;
+// _t is the time at which we want the OTP to be valid for
+console.log(notp.totp.gen(bin, {_t: time}));

--- a/scripts/generate-otp.js
+++ b/scripts/generate-otp.js
@@ -1,3 +1,6 @@
+const EOL = require("os").EOL;
+const path = require("path");
+const fs = require("fs");
 // we want to generate a TOTP in the _future_, and the `notp`
 // library doesn't let us do that unless we set `NODE_ENV = "test"`
 process.env.NODE_ENV = "test";
@@ -8,8 +11,11 @@ const bin = b32.decode(process.env.NPM_OTP_KEY);
 // generate a code 5 seconds in the future
 // 5 seconds is arbitrary, and may need to be tweaked if
 // the release process is discovered to be too fast or too slow.
-const timeOffset = 5000;
+const timeOffset = 1000;
 const now = Date.now();
 const time = now + timeOffset;
 // _t is the time at which we want the OTP to be valid for
-console.log(notp.totp.gen(bin, {_t: time}));
+const otp = notp.totp.gen(bin, {_t: time});
+
+// save to .npmrc so `npm publish` can pick it up later
+fs.appendFileSync(path.join(__dirname, "..", ".npmrc"), `${EOL}otp=${otp}`);


### PR DESCRIPTION
<h4>
  <p align="center">
		<code>&nbsp;<a href="#user-content-v6.10.1-highlights">Highlights</a>&nbsp;</code>&nbsp;
		<img height="36" width="0" src="https://raw.githubusercontent.com/davidmurdoch/px/master/1px.gif">
		<code>&nbsp;<a href="#user-content-v6.10.1-how-to-upgrade">How&nbsp;to&nbsp;Upgrade</a>&nbsp;</code>&nbsp;
		<img height="36" width="0" src="https://raw.githubusercontent.com/davidmurdoch/px/master/1px.gif">
		<code>&nbsp;<a href="#user-content-v6.10.1-changelog">Changelog</a>&nbsp;</code>&nbsp;
		<img height="36" width="0" src="https://raw.githubusercontent.com/davidmurdoch/px/master/1px.gif">
		<code>&nbsp;<a href="#user-content-v6.10.1-related-releases">Related&nbsp;Releases</a>&nbsp;</code>
		<img height="36" width="0" src="https://raw.githubusercontent.com/davidmurdoch/px/master/1px.gif">
  </p>
</h4>

---

We're moving to a `beta` › `latest` release pipeline, where all non-hotfix changes are first released in a beta before being promoted to a stable release.

We'd love it if you'd start using the latest betas and let us know early and often if you find any bugs or regressions!

## <a name="v6.10.1-Highlights"></a>Highlights

v6.10.1 – Coffee Cake ☕

I just learned that Coffee Cake _doesn't_ taste like coffee?! I've had it a hundred times and never thought about it...

And like coffee, this release will get things done faster! @fubhy's work to improve the performance of forking has resulted in real-world tests running up to 20 times faster than before!

@fubhy also fixed a bug when forking while using accounts with non-zero nonces. These accounts were not initialized properly on start up, resulting in nonce errors when running transactions.

---

<p align="center">
  💖 The Truffle Team
</p>

##  <a name="v6.10.1-how-to-upgrade"></a>How to Upgrade

Upgrade to the latest version of ganache-cli by running:

#### npm

```console
npm uninstall ganache-cli -g
npm install ganache-cli -g
```

#### yarn

```console
yarn global remove ganache-cli
yarn global add ganache-cli
```

<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=ganache-cli-release-notes&ea=view&t=event&tid=UA-83874933-3&z=1555689382&cid=8e96b31f-f857-4e4b-9520-df5cd3a52af0&dt=v6.10.1&dp=/github.com/">

##  <a name="v6.10.1-related-releases"></a>Related Releases

 * [ganache-core v2.11.2](https://github.com/trufflesuite/ganache-core/releases/tag/v2.11.2)

##  <a name="v6.10.1-changelog"></a>Changelog
